### PR TITLE
refactor: reuse escape map for HTML escaping

### DIFF
--- a/china-motors-site/js/catalog.js
+++ b/china-motors-site/js/catalog.js
@@ -27,8 +27,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const nfRU = new Intl.NumberFormat('ru-RU');
   const fmtPrice = n => (n===0 || n) ? `${nfRU.format(Number(n))}$` : 'Цена по запросу';
-  const escHTML = s => String(s ?? '').replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
-  const escAttr = s => escHTML(s).replace(/"/g,'&quot;');
+  const escapeMap = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  const escHTML = s => String(s ?? '').replace(/[&<>"']/g,m=>escapeMap[m]);
+  const escAttr = escHTML;
 
   function canonBody(rawTitle, rawBody){
     const s = `${rawTitle} ${rawBody}`.toLowerCase();


### PR DESCRIPTION
## Summary
- reuse a shared `escapeMap` for HTML escaping
- streamline attribute escaping by reusing `escHTML`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf7f1bbbc83258c625120afdf22b7