### PR TITLE
Move lazy load setup into onReady

### DIFF
--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -32,6 +32,15 @@
       s1.setAttribute('crossorigin', '*');
       document.body.appendChild(s1);
     }
+
+    // Ленивая загрузка для всех картинок и видео, если атрибутов нет
+    document.querySelectorAll('img:not([loading])').forEach(img => {
+      img.setAttribute('loading', 'lazy');
+      img.setAttribute('decoding', 'async');
+    });
+    document
+      .querySelectorAll('video[preload="auto"]')
+      .forEach(v => v.setAttribute('preload', 'metadata'));
   };
 
   if (document.readyState === 'loading') {
@@ -39,10 +48,4 @@
   } else {
     onReady();
   }
-      // Ленивая загрузка для всех картинок и видео, если атрибутов нет
-    document.querySelectorAll('img:not([loading])').forEach(img => {
-        img.setAttribute('loading', 'lazy');
-        img.setAttribute('decoding', 'async');
-    });
-    document.querySelectorAll('video[preload="auto"]').forEach(v => v.setAttribute('preload', 'metadata'));
 })();


### PR DESCRIPTION
## Summary
- relocate lazy load setup for images and videos into `onReady`
- keep DOMContentLoaded listener so code runs after the DOM is ready

## Testing
- `node --check china-motors-site/js/common.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdf73b07848325835144335a5b22c6