### PR TITLE
Validate phone and message before sending contact form

### DIFF
--- a/china-motors-site/js/contacts.js
+++ b/china-motors-site/js/contacts.js
@@ -34,8 +34,25 @@ document.addEventListener('DOMContentLoaded', () => {
   sendBtn?.addEventListener('click', async (e) => {
     e.preventDefault();
     const name = nameEl?.value?.trim() || '—';
-    const phone = phoneEl?.value?.trim() || '—';
-    const msg = msgEl?.value?.trim() || '—';
+    const phone = phoneEl?.value?.trim() || '';
+    const msg = msgEl?.value?.trim() || '';
+
+    // simple validation
+    let valid = true;
+    phoneEl?.style.removeProperty('border-color');
+    msgEl?.style.removeProperty('border-color');
+    if (!phone || !/^\+?[0-9\s-]{6,}$/.test(phone)) {
+      phoneEl?.style.setProperty('border-color', 'red');
+      valid = false;
+    }
+    if (!msg) {
+      msgEl?.style.setProperty('border-color', 'red');
+      valid = false;
+    }
+    if (!valid) {
+      alert('Пожалуйста, корректно заполните телефон и сообщение');
+      return;
+    }
 
     const text =
       `📩 <b>Новая заявка</b>\n` +


### PR DESCRIPTION
## Summary
- add simple phone number and message validation before submitting the contact form
- highlight invalid fields and abort submission on invalid input

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be013784388325bf21200252add745