### PR TITLE
Allow configurable API base for contact form

### DIFF
--- a/china-motors-site/contacts.html
+++ b/china-motors-site/contacts.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="ru">
 <head>
+  <!-- УКАЖИ СЮДА СВОЙ БЭКЕНД (прод): -->
+  <meta name="api-base" content="https://cm-backend-daniyal.fly.dev">
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>China Motors - Контакты</title>

--- a/china-motors-site/js/contacts.js
+++ b/china-motors-site/js/contacts.js
@@ -1,9 +1,8 @@
 // /js/contacts.js
 document.addEventListener('DOMContentLoaded', () => {
-  const API_BASE =
-    (location.hostname === '127.0.0.1' || location.hostname === 'localhost')
-      ? 'http://127.0.0.1:8000'
-      : 'https://cm-backend-daniyal.fly.dev';
+  const metaBase = document.querySelector('meta[name="api-base"]')?.content?.trim();
+  const isLocal = /^(localhost|127\.0\.0\.1)$/.test(location.hostname);
+  const API_BASE = (metaBase || (isLocal ? 'http://127.0.0.1:8000' : 'https://cm-backend-daniyal.fly.dev')).replace(/\/+$/, '');
 
   const nameEl = document.getElementById('c-name');
   const phoneEl = document.getElementById('c-phone');
@@ -59,3 +58,4 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 });
+


### PR DESCRIPTION
## Summary
- allow overriding contact form backend via `<meta name="api-base">`
- read API base from meta and normalize slashes in contacts.js
- add `api-base` meta tag to contacts.html

## Testing
- `node --check china-motors-site/js/contacts.js`


------
https://chatgpt.com/codex/tasks/task_e_68be01309b4c832587c51d0b1435637f