### PR TITLE
Display catalog and product prices in CNY instead of USD

### DIFF
--- a/china-motors-site/js/catalog.js
+++ b/china-motors-site/js/catalog.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
   /* ================= HELPERS ================= */
 
   const nf = new Intl.NumberFormat('ru-RU');
-  const fmtPrice = v => v ? `${nf.format(v)}$` : 'Цена уточняется';
+  const fmtPrice = v => v ? `${nf.format(v)}¥` : 'Цена уточняется';
 
   function canonBody(title = '', raw = '') {
     const s = `${title} ${raw}`.toLowerCase();
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return {
       id: v.id,
       title,
-      price: Number(v.price_usd) || null,
+      price: Number(v.price_cny) || null,
       year: v.year || null,
       bodyType: canonBody(title, bodyRaw),
       bodyRaw,
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
           <div class="cm-card__footer">
             <div class="price">
-              ${item.price ? `${item.price.toLocaleString('ru-RU')} $` : 'Цена уточняется'}
+              ${item.price ? `${item.price.toLocaleString('ru-RU')} ¥` : 'Цена уточняется'}
             </div>
             <span data-i18n="btn_calculate_catalog" class="btn-outline">Подробнее и расчёт</span>
           </div>

--- a/china-motors-site/js/product.js
+++ b/china-motors-site/js/product.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // === helpers (вынесено из catalog.js логики) ===
   const nf = new Intl.NumberFormat('ru-RU');
-  const fmtPrice = n => (n === 0 || n) ? `${nf.format(Number(n))}$` : 'Цена по запросу';
+  const fmtPrice = n => (n === 0 || n) ? `${nf.format(Number(n))}¥` : 'Цена по запросу';
 
   function pickImages(v) {
     if (Array.isArray(v.images) && v.images.length) return v.images;
@@ -36,6 +36,11 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function pickPrice(v) {
+    return v.price_cny ?? v.priceCNY ?? null;
+  }
+
+  // Только для автоподстановки в калькулятор (тот считает в USD).
+  function pickPriceUsd(v) {
     return v.price_usd ?? v.usd_price ?? v.priceUSD ?? null;
   }
 
@@ -76,7 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ['Модель', v.model],
       ['Год выпуска', v.year],
       ['Конструкция', v.body_type],
-      ['Цена', v.price_usd ? `${v.price_usd}$` : null],
+      ['Цена', v.price_cny ? `${v.price_cny}¥` : null],
       ['Масса, т', v.weight_t],
       ['Пробег, км', v.mileage_km],
     ];
@@ -123,6 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
         [v.brand, v.model, v.name].filter(Boolean).join(' ').trim() || 'Без названия';
 
       const priceNum = pickPrice(v);
+      const priceUsdForCalc = pickPriceUsd(v);
       const images = pickImages(v);
       const bodyRaw = pickBodyRaw(v);
       const bodyCanon = canonBody(title, bodyRaw);
@@ -143,7 +149,7 @@ document.addEventListener('DOMContentLoaded', () => {
         btnCalc.href =
           `calculator.html?` +
           `title=${encodeURIComponent(title)}` +
-          `&price=${encodeURIComponent(priceNum ?? '')}` +
+          `&price=${encodeURIComponent(priceUsdForCalc ?? '')}` +
           `&body=${encodeURIComponent(bodyCanon)}` +
           `&body_raw=${encodeURIComponent(bodyRaw || '')}` +
           `&weight=${encodeURIComponent(v.weight_t ?? '')}` +


### PR DESCRIPTION
Backend now exposes price_cny alongside price_usd. price_usd is kept around purely to autofill the cost calculator (which computes in USD), but everything shown to the visitor — catalog cards, product page, contact request message — now reads from price_cny with a ¥ suffix.