### PR TITLE
Bump service worker cache version to bust stale cached JS

### DIFF
--- a/china-motors-site/sw.js
+++ b/china-motors-site/sw.js
@@ -1,4 +1,6 @@
-const CACHE_VERSION = 'v1.0.0';
+// Bump this on every deploy that changes a file listed in STATIC_ASSETS below —
+// cacheFirst() means old visitors never see updated JS/CSS until this changes.
+const CACHE_VERSION = 'v1.0.1';
 const STATIC_CACHE = `cm-static-${CACHE_VERSION}`;
 const PAGES_CACHE = `cm-pages-${CACHE_VERSION}`;
 


### PR DESCRIPTION
catalog.js/calculator.js/etc. are served cache-first by the service worker, keyed by CACHE_VERSION. Visitors who already had the SW installed kept getting the pre-CNY-pricing catalog.js after the last deploy since the cache key never changed. Bumping it forces everyone to pick up fresh static assets on next visit.