### PR TITLE
Show availability badge (in stock / out of stock / on order) on vehicles

### DIFF
--- a/china-motors-site/js/catalog.js
+++ b/china-motors-site/js/catalog.js
@@ -23,6 +23,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const nf = new Intl.NumberFormat('ru-RU');
   const fmtPrice = v => v ? `${nf.format(v)}¥` : 'Цена уточняется';
 
+  const AVAIL_LABELS = {
+    in_stock: 'В наличии',
+    out_of_stock: 'Нет в наличии',
+    on_order: 'На заказ'
+  };
+
   function canonBody(title = '', raw = '') {
     const s = `${title} ${raw}`.toLowerCase();
 
@@ -51,7 +57,8 @@ document.addEventListener('DOMContentLoaded', () => {
       year: v.year || null,
       bodyType: canonBody(title, bodyRaw),
       bodyRaw,
-      image: v.image_url || '/img/no-photo.png'
+      image: v.image_url || '/img/no-photo.png',
+      availability: v.availability || 'in_stock'
     };
   }
 
@@ -62,6 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <a class="cm-card" href="product.html?id=${item.id}">
         <div class="cm-card__image">
           <img src="${item.image}" alt="${item.title}">
+          <span class="cm-badge cm-badge--${item.availability}">${AVAIL_LABELS[item.availability] || ''}</span>
         </div>
 
         <div class="cm-card__body">

--- a/china-motors-site/js/product.js
+++ b/china-motors-site/js/product.js
@@ -39,6 +39,12 @@ document.addEventListener('DOMContentLoaded', () => {
     return v.price_cny ?? v.priceCNY ?? null;
   }
 
+  const AVAIL_LABELS = {
+    in_stock: 'В наличии',
+    out_of_stock: 'Нет в наличии',
+    on_order: 'На заказ'
+  };
+
   // Только для автоподстановки в калькулятор (тот считает в USD).
   function pickPriceUsd(v) {
     return v.price_usd ?? v.usd_price ?? v.priceUSD ?? null;
@@ -82,6 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ['Год выпуска', v.year],
       ['Конструкция', v.body_type],
       ['Цена', v.price_cny ? `${v.price_cny}¥` : null],
+      ['Наличие', AVAIL_LABELS[v.availability] || null],
       ['Масса, т', v.weight_t],
       ['Пробег, км', v.mileage_km],
     ];

--- a/china-motors-site/style.css
+++ b/china-motors-site/style.css
@@ -1939,10 +1939,39 @@ html.dark .cm-card {
 }
 
 /* IMAGE */
+.cm-card__image {
+  position: relative;
+}
+
 .cm-card__image img {
   width: 100%;
   height: 220px;
   object-fit: cover;
+}
+
+/* AVAILABILITY BADGE */
+.cm-badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0,0,0,.25);
+}
+
+.cm-badge--in_stock {
+  background: #2ecc71;
+}
+
+.cm-badge--out_of_stock {
+  background: #e74c3c;
+}
+
+.cm-badge--on_order {
+  background: #f39c12;
 }
 
 /* BODY */


### PR DESCRIPTION
Catalog cards get a colored badge over the photo (green/red/orange); the product page shows the same status as a row in the specs table. Backed by the new availability field on the Vehicle model.