### PR TITLE
Add product image lightbox, quick catalog filters, styled trust list

### DIFF
--- a/china-motors-site/catalog.html
+++ b/china-motors-site/catalog.html
@@ -101,6 +101,18 @@
             <option value="price_desc" data-i18n="sort_price_desc">Цена ↓</option>
           </select>
         </div>
+        <div class="f">
+          <label for="brand">Марка</label>
+          <select id="brand">
+            <option value="">Все марки</option>
+          </select>
+        </div>
+        <div class="f">
+          <label for="wheelFormula">Колёсная формула</label>
+          <select id="wheelFormula">
+            <option value="">Любая</option>
+          </select>
+        </div>
       </div>
 
       <div id="grid" class="feature-grid"></div>

--- a/china-motors-site/js/catalog.js
+++ b/china-motors-site/js/catalog.js
@@ -17,6 +17,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const bodyEl   = document.getElementById('body');
   const sortEl   = document.getElementById('sort');
   const searchEl = document.getElementById('search');
+  const brandEl  = document.getElementById('brand');
+  const wheelEl  = document.getElementById('wheelFormula');
 
   /* ================= HELPERS ================= */
 
@@ -28,6 +30,17 @@ document.addEventListener('DOMContentLoaded', () => {
     out_of_stock: 'Нет в наличии',
     on_order: 'На заказ'
   };
+
+  // Приводим "6×4", "6X4", "6х4" (кириллица) к одному виду "6x4",
+  // чтобы поиск/фильтр не зависели от того, каким символом набрана "х".
+  function normText(s) {
+    return (s || '').toLowerCase().replace(/[×х]/g, 'x');
+  }
+
+  function extractWheelFormula(text) {
+    const m = normText(text).match(/(\d)\s*x\s*(\d)/);
+    return m ? `${m[1]}x${m[2]}` : '';
+  }
 
   function canonBody(title = '', raw = '') {
     const s = `${title} ${raw}`.toLowerCase();
@@ -57,6 +70,8 @@ document.addEventListener('DOMContentLoaded', () => {
       year: v.year || null,
       bodyType: canonBody(title, bodyRaw),
       bodyRaw,
+      brand: v.brand || '',
+      wheelFormula: extractWheelFormula(`${title} ${bodyRaw}`),
       image: v.image_url || '/img/no-photo.png',
       availability: v.availability || 'in_stock'
     };
@@ -117,14 +132,42 @@ document.addEventListener('DOMContentLoaded', () => {
   let all = [];
   let current = [];
 
+  function populateSelect(selectEl, values) {
+    if (!selectEl) return;
+    const current = selectEl.value;
+    const placeholder = selectEl.querySelector('option[value=""]');
+    selectEl.innerHTML = '';
+    if (placeholder) selectEl.appendChild(placeholder);
+    values.forEach(v => {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = v;
+      selectEl.appendChild(opt);
+    });
+    if (values.includes(current)) selectEl.value = current;
+  }
+
+  function populateQuickFilters() {
+    const brands = [...new Set(all.map(x => x.brand).filter(Boolean))].sort();
+    const wheels = [...new Set(all.map(x => x.wheelFormula).filter(Boolean))].sort();
+    populateSelect(brandEl, brands);
+    populateSelect(wheelEl, wheels);
+  }
+
   function applyFilters() {
     const b = bodyEl?.value || '';
-    const q = (searchEl?.value || '').toLowerCase();
+    const brand = brandEl?.value || '';
+    const wheel = wheelEl?.value || '';
+    const q = normText(searchEl?.value || '');
 
     current = all.filter(x => {
       const bodyOk = !b || x.bodyType === b;
-      const searchOk = !q || x.title.toLowerCase().includes(q);
-      return bodyOk && searchOk;
+      const brandOk = !brand || x.brand === brand;
+      const wheelOk = !wheel || x.wheelFormula === wheel;
+      const searchOk = !q ||
+        normText(x.title).includes(q) ||
+        normText(x.bodyRaw).includes(q);
+      return bodyOk && brandOk && wheelOk && searchOk;
     });
   }
 
@@ -143,6 +186,8 @@ document.addEventListener('DOMContentLoaded', () => {
   bodyEl?.addEventListener('change', refilter);
   sortEl?.addEventListener('change', refilter);
   searchEl?.addEventListener('input', refilter);
+  brandEl?.addEventListener('change', refilter);
+  wheelEl?.addEventListener('change', refilter);
 
   /* ================= LOAD ================= */
 
@@ -155,6 +200,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const list = Array.isArray(data) ? data : data.results || [];
 
       all = list.map(normalize).filter(Boolean);
+      populateQuickFilters();
       refilter();
 
     } catch (e) {

--- a/china-motors-site/js/product.js
+++ b/china-motors-site/js/product.js
@@ -23,6 +23,47 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const btnCalc = document.getElementById('btnCalc');
   const btnReq  = document.getElementById('btnRequest');
+  const extraEl = document.getElementById('extraInfo');
+
+  // === LIGHTBOX ===
+  const lightbox     = document.getElementById('lightbox');
+  const lightboxImg  = document.getElementById('lightboxImg');
+  const lightboxPrev = document.getElementById('lightboxPrev');
+  const lightboxNext = document.getElementById('lightboxNext');
+  const lightboxClose = document.getElementById('lightboxClose');
+
+  let galleryImages = [];
+  let lightboxIndex = 0;
+
+  function showLightboxImage(i) {
+    if (!galleryImages.length) return;
+    lightboxIndex = (i + galleryImages.length) % galleryImages.length;
+    lightboxImg.src = galleryImages[lightboxIndex];
+  }
+
+  function openLightbox(i) {
+    if (!galleryImages.length) return;
+    showLightboxImage(i);
+    lightbox.classList.add('open');
+  }
+
+  function closeLightbox() {
+    lightbox.classList.remove('open');
+  }
+
+  lightboxClose?.addEventListener('click', closeLightbox);
+  lightboxPrev?.addEventListener('click', () => showLightboxImage(lightboxIndex - 1));
+  lightboxNext?.addEventListener('click', () => showLightboxImage(lightboxIndex + 1));
+  lightboxImg?.addEventListener('click', closeLightbox);
+  lightbox?.addEventListener('click', (e) => {
+    if (e.target === lightbox) closeLightbox();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (!lightbox.classList.contains('open')) return;
+    if (e.key === 'Escape') closeLightbox();
+    if (e.key === 'ArrowLeft') showLightboxImage(lightboxIndex - 1);
+    if (e.key === 'ArrowRight') showLightboxImage(lightboxIndex + 1);
+  });
 
   // === helpers (вынесено из catalog.js логики) ===
   const nf = new Intl.NumberFormat('ru-RU');
@@ -104,9 +145,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function buildGallery(images) {
     if (!images.length) return;
+    galleryImages = images;
 
     mainImg.src = images[0];
     mainImg.alt = titleEl.textContent;
+    mainImg.addEventListener('click', () => {
+      const activeIdx = Math.max(0, [...thumbsEl.querySelectorAll('img')].findIndex(t => t.classList.contains('active')));
+      openLightbox(activeIdx);
+    });
 
     thumbsEl.innerHTML = '';
     images.forEach((src, i) => {
@@ -150,6 +196,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
       buildGallery(images);
       buildSpecsTable(v);
+
+      if (v.extra_info && extraEl) {
+        extraEl.textContent = v.extra_info;
+        extraEl.style.display = '';
+      }
 
       // === buttons ===
       if (btnCalc) {

--- a/china-motors-site/product.html
+++ b/china-motors-site/product.html
@@ -36,6 +36,7 @@
       object-fit: contain;
       background: #111;
       border-radius: 16px;
+      cursor: zoom-in;
     }
 
     .thumbs {
@@ -53,6 +54,90 @@
       opacity: .75;
     }
     .thumbs img.active { opacity: 1; outline: 2px solid #e11d48; }
+
+    /* LIGHTBOX */
+    .pg-lightbox {
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,.88);
+    }
+    .pg-lightbox.open { display: flex; }
+    .pg-lightbox img {
+      max-width: 92vw;
+      max-height: 88vh;
+      object-fit: contain;
+      cursor: zoom-out;
+      user-select: none;
+    }
+    .pg-lightbox__close {
+      position: absolute;
+      top: 18px;
+      right: 24px;
+      width: 44px;
+      height: 44px;
+      border-radius: 999px;
+      border: none;
+      background: rgba(255,255,255,.14);
+      color: #fff;
+      font-size: 22px;
+      cursor: pointer;
+    }
+    .pg-lightbox__close:hover { background: rgba(255,255,255,.24); }
+    .pg-lightbox__nav {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 48px;
+      height: 48px;
+      border-radius: 999px;
+      border: none;
+      background: rgba(255,255,255,.14);
+      color: #fff;
+      font-size: 22px;
+      cursor: pointer;
+    }
+    .pg-lightbox__nav:hover { background: rgba(255,255,255,.24); }
+    .pg-lightbox__nav--prev { left: 18px; }
+    .pg-lightbox__nav--next { right: 18px; }
+
+    /* TRUST LIST */
+    .trust-list {
+      list-style: none;
+      margin: 22px 0 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .trust-list li {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 16px;
+      background: rgba(255,255,255,.04);
+      border: 1px solid rgba(255,255,255,.08);
+      border-radius: 12px;
+      font-size: 15px;
+    }
+    .trust-list li i {
+      color: #ff3b30;
+      font-size: 16px;
+      flex-shrink: 0;
+    }
+
+    /* EXTRA INFO */
+    .product-extra {
+      margin-top: 24px;
+      padding-top: 16px;
+      border-top: 1px solid rgba(255,255,255,.08);
+      white-space: pre-line;
+      line-height: 1.6;
+      opacity: .9;
+    }
 
     .product-title { font-size: 28px; font-weight: 700; margin-bottom: 10px; }
     .product-price { font-size: 22px; font-weight: 700; margin: 16px 0; }
@@ -105,10 +190,15 @@
             <i class="fa fa-calculator"></i> Рассчитать стоимость
           </a>
         </div>
-        <p data-i18n="why_card1_y">✔ Работа по договору</p>  
-        <p data-i18n="why_card2_y">✔ Фото и видео с погрузки и доставки</p>  
-        <p data-i18n="why_card3_y">✔ Прозрачный расчёт без «вдруг доплатите»</p>  
-        <p data-i18n="why_card4_y">✔ Помощь с таможней и регистрацией</p>
+
+        <ul class="trust-list">
+          <li><i class="fa-solid fa-file-signature"></i><span data-i18n="why_card1_y">Работа по договору</span></li>
+          <li><i class="fa-solid fa-camera"></i><span data-i18n="why_card2_y">Фото и видео с погрузки и доставки</span></li>
+          <li><i class="fa-solid fa-calculator"></i><span data-i18n="why_card3_y">Прозрачный расчёт без «вдруг доплатите»</span></li>
+          <li><i class="fa-solid fa-file-shield"></i><span data-i18n="why_card4_y">Помощь с таможней и регистрацией</span></li>
+        </ul>
+
+        <div class="product-extra" id="extraInfo" style="display:none"></div>
       </div>
 
     </div>
@@ -116,6 +206,14 @@
 </section>
 
 <div id="siteFooter"></div>
+
+<!-- LIGHTBOX -->
+<div class="pg-lightbox" id="lightbox">
+  <button class="pg-lightbox__close" id="lightboxClose" aria-label="Закрыть">✕</button>
+  <button class="pg-lightbox__nav pg-lightbox__nav--prev" id="lightboxPrev" aria-label="Предыдущее фото">‹</button>
+  <img id="lightboxImg" src="" alt="">
+  <button class="pg-lightbox__nav pg-lightbox__nav--next" id="lightboxNext" aria-label="Следующее фото">›</button>
+</div>
 
 <!-- scripts -->
 <script src="js/common.js"></script>


### PR DESCRIPTION
- product.html/product.js: click-to-zoom lightbox for the gallery (prev/next, Escape, click-outside), styled trust bullet list, and an extra_info block wired to the new backend field
- catalog.js: search now also matches body_type/wheel-formula text (normalizes 6x4 / 6×4 / 6х4 to one form); added Brand and Wheel Formula quick-filter dropdowns, populated dynamically from the loaded vehicles
- catalog.html: markup for the two new filter selects