### PR TITLE
Show full specs on product page, make body-type filter dynamic too

### DIFF
--- a/china-motors-site/catalog.html
+++ b/china-motors-site/catalog.html
@@ -75,22 +75,6 @@
           <label for="body" data-i18n="filter_body_label">Тип транспорта</label>
           <select id="body">
             <option value="" data-i18n="body_all">{Все}</option>
-            <option value="Прицепы" data-i18n="body_trailer">Прицепы</option>
-            <option value="Полуприцепы" data-i18n="body_semitrailer">Полуприцепы</option>
-            <option value="Самосвал" data-i18n="body_dumptruck">Самосвал</option>
-            <option value="Тягач" data-i18n="body_tugboat">Тягач</option>
-            <option value="Спец. техника" data-i18n="body_specialequipment">Спец. техника</option>
-            <option value="Кран" data-i18n="body_crane">Кран</option>
-            <option value="Спец. техника" data-i18n="body_manipulator">Манипулятор</option>
-            <option value="Спец. техника" data-i18n="body_mixer">Миксер</option>
-            <option value="Спец. техника" data-i18n="body_aerial_ladder">Автовышка</option>
-            <option value="Спец. техника" data-i18n="body_sewer_cleaner">Ассенизатор</option>
-            <option value="Рефрижератор" data-i18n="body_refrigerator">Рефрижератор</option>
-            <option value="Автофургон" data-i18n="body_van">Автофургон</option>
-            <option value="Спец. техника" data-i18n="body_sprinkler">Поливомоечная машина</option>
-            <option value="Ямобур машины для бурения" data-i18n="body_drilling_rig">Ямобур машины для бурения</option>
-            <option value="Молоковоз" data-i18n="body_milk_truck">Молоковоз</option>
-            <option value="Топливозаправщик" data-i18n="body_fuel_truck">Топливозаправщик</option>
           </select>
         </div>
         <div class="f">

--- a/china-motors-site/js/catalog.js
+++ b/china-motors-site/js/catalog.js
@@ -71,9 +71,10 @@ document.addEventListener('DOMContentLoaded', () => {
       bodyType: canonBody(title, bodyRaw),
       bodyRaw,
       brand: v.brand || '',
-      wheelFormula: extractWheelFormula(`${title} ${bodyRaw}`),
+      wheelFormula: normText(v.wheel_formula || '') || extractWheelFormula(`${title} ${bodyRaw}`),
       image: v.image_url || '/img/no-photo.png',
-      availability: v.availability || 'in_stock'
+      availability: v.availability || 'in_stock',
+      raw: v
     };
   }
 
@@ -148,8 +149,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function populateQuickFilters() {
+    const bodies = [...new Set(all.map(x => x.bodyType).filter(Boolean))].sort();
     const brands = [...new Set(all.map(x => x.brand).filter(Boolean))].sort();
     const wheels = [...new Set(all.map(x => x.wheelFormula).filter(Boolean))].sort();
+    populateSelect(bodyEl, bodies);
     populateSelect(brandEl, brands);
     populateSelect(wheelEl, wheels);
   }

--- a/china-motors-site/js/product.js
+++ b/china-motors-site/js/product.js
@@ -151,20 +151,25 @@ document.addEventListener('DOMContentLoaded', () => {
     specsEl.innerHTML = '';
 
     const rows = [
-      ['Бренд', v.brand],
-      ['Модель', v.model],
-      ['Год выпуска', v.year],
-      ['Конструкция', v.body_type],
-      ['Цена', v.price_cny ? `${v.price_cny}¥` : null],
-      ['Наличие', AVAIL_LABELS[v.availability] || null],
-      ['Масса, т', v.weight_t],
-      ['Пробег, км', v.mileage_km],
+      ['fa-industry', 'Бренд', v.brand],
+      ['fa-hashtag', 'Модель', v.model],
+      ['fa-calendar', 'Год выпуска', v.year],
+      ['fa-truck', 'Конструкция', v.body_type],
+      ['fa-road', 'Колёсная формула', v.wheel_formula],
+      ['fa-gears', 'КПП', v.gearbox],
+      ['fa-bolt', 'Мощность двигателя', v.engine_power_hp ? `${v.engine_power_hp} л.с.` : null],
+      ['fa-weight-hanging', 'Грузоподъёмность', v.load_capacity_t ? `${v.load_capacity_t} т` : null],
+      ['fa-gauge-high', 'Макс. скорость', v.max_speed_kmh ? `${v.max_speed_kmh} км/ч` : null],
+      ['fa-tag', 'Цена', v.price_cny ? `${v.price_cny}¥` : null],
+      ['fa-circle-check', 'Наличие', AVAIL_LABELS[v.availability] || null],
+      ['fa-weight', 'Масса, т', v.weight_t],
+      ['fa-road-circle-check', 'Пробег, км', v.mileage_km],
     ];
 
-    rows.forEach(([label, value]) => {
+    rows.forEach(([icon, label, value]) => {
       if (value === null || value === undefined || value === '') return;
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${label}</td><td><strong>${value}</strong></td>`;
+      tr.innerHTML = `<td><i class="fa-solid ${icon}"></i>${label}</td><td>${value}</td>`;
       specsEl.appendChild(tr);
     });
   }

--- a/china-motors-site/product.html
+++ b/china-motors-site/product.html
@@ -55,15 +55,6 @@
     }
     .thumbs img.active { opacity: 1; outline: 2px solid #e11d48; }
 
-    .product-video {
-      margin-top: 16px;
-      display: flex;
-      justify-content: center;
-    }
-    .product-video blockquote.tiktok-embed {
-      margin: 0 !important;
-    }
-
     /* LIGHTBOX */
     .pg-lightbox {
       position: fixed;
@@ -153,14 +144,44 @@
 
     table.specs {
       width: 100%;
-      border-collapse: collapse;
+      border-collapse: separate;
+      border-spacing: 0 6px;
       margin-top: 20px;
     }
-    table.specs td {
-      padding: 10px 8px;
-      border-bottom: 1px solid rgba(255,255,255,.08);
+    table.specs tr {
+      background: rgba(255,255,255,.04);
     }
-    table.specs td:first-child { opacity: .75; width: 45%; }
+    table.specs td {
+      padding: 12px 16px;
+      border: none;
+    }
+    table.specs td:first-child {
+      opacity: .7;
+      font-size: 13px;
+      width: 50%;
+      border-radius: 10px 0 0 10px;
+    }
+    table.specs td:last-child {
+      text-align: right;
+      font-weight: 600;
+      border-radius: 0 10px 10px 0;
+    }
+    table.specs td i {
+      width: 16px;
+      margin-right: 8px;
+      color: #ff3b30;
+    }
+
+    /* FULL-WIDTH VIDEO SECTION */
+    .product-video-section {
+      margin-top: 40px;
+      display: flex;
+      justify-content: center;
+    }
+    .product-video-section blockquote.tiktok-embed {
+      margin: 0 !important;
+      max-width: 100% !important;
+    }
 
     .product-actions {
       display: flex;
@@ -184,7 +205,6 @@
       <div class="product-gallery">
         <img id="mainImage" src="" alt="">
         <div class="thumbs" id="thumbs"></div>
-        <div class="product-video" id="videoReview" style="display:none"></div>
       </div>
 
       <!-- ПРАВО: ИНФО -->
@@ -212,6 +232,8 @@
       </div>
 
     </div>
+
+    <div class="product-video-section" id="videoReview" style="display:none"></div>
   </div>
 </section>
 


### PR DESCRIPTION
- product.html/product.js: specs table restyled as rounded rows with icons; added wheel formula, gearbox, engine power, load capacity, max speed rows (backed by new fields on the backend); moved the TikTok video out of the narrow gallery column into a full-width section below the whole grid so it isn't squeezed
- catalog.js: "Тип транспорта" filter is now populated dynamically from the loaded vehicles, same as Brand and Wheel Formula, instead of a static hardcoded option list; cards now carry the raw vehicle object so their wheel_formula/gearbox rows actually render