### PR TITLE
Reconcile calculator fees with real customs-clearance spreadsheet

### DIFF
--- a/china-motors-site/js/calculator.js
+++ b/china-motors-site/js/calculator.js
@@ -54,10 +54,22 @@
      ========================================================= */
   const CALC_DEFAULT_CONFIG = {
     currency: { usd_kzt: 540, cny_kzt: 68.5 },
+    diesel: { price_kzt_per_l: 335, liters: 200 },
     taxes: { vat: 0.12, duty: 0.10 },
     fees: {
       plate: 16963,
-      first_registration: 1376000
+      first_registration: 1376000,
+      srtc: 17516,
+      eptc: 50000,
+      sbkts: 150000,
+      sos: 200000,
+      customs_fee: 25950,
+      broker_service: 90000,
+      red_corridor: 450000,
+      adblue: 13500,
+      driver: 65000,
+      insurance: 5000,
+      toll_road: 9000
     },
     util_2026: {
       TRACTOR_N3: 2162600,
@@ -77,6 +89,7 @@
         ...CALC_DEFAULT_CONFIG,
         ...data,
         currency: { ...CALC_DEFAULT_CONFIG.currency, ...data.currency },
+        diesel: { ...CALC_DEFAULT_CONFIG.diesel, ...data.diesel },
         taxes: { ...CALC_DEFAULT_CONFIG.taxes, ...data.taxes },
         fees: { ...CALC_DEFAULT_CONFIG.fees, ...data.fees },
         util_2026: { ...CALC_DEFAULT_CONFIG.util_2026, ...data.util_2026 }
@@ -307,10 +320,13 @@
    ========================================================= */
 
   function getExpensePackage(profile, excelMax, rate) {
-    // дизель: 220 литров × цена из конфига
-    const dieselLiters = 220;
-    const dieselPrice = CALC_CONFIG.diesel?.price_kzt_per_l || 360;
-    const dieselSum = dieselLiters * dieselPrice;
+    const fees = CALC_CONFIG.fees;
+
+    // Дизель + AdBlue одним пакетом (см. calc_item_diesel_pack)
+    const dieselLiters = CALC_CONFIG.diesel?.liters || 200;
+    const dieselPrice = CALC_CONFIG.diesel?.price_kzt_per_l || 335;
+    const dieselSum = dieselLiters * dieselPrice + (fees.adblue || 0);
+
     // ✅ Декларант на границе: 250$ × курс
     const declarantUSD = 250;
     const declarantSum = declarantUSD * rate;
@@ -337,8 +353,8 @@
     if (!excelMax) {
       return {
         mandatory: [
-          ['calc_item_customs_fee', 29592],
-          ['calc_item_broker_service', 90000]
+          ['calc_item_customs_fee', fees.customs_fee],
+          ['calc_item_broker_service', fees.broker_service]
         ],
         delivery: [
           ['calc_item_delivery_city', 150000]
@@ -349,10 +365,11 @@
     // Excel / максимум
     return {
       mandatory: [
-        ['calc_item_sbkts', 200000],
-        ['calc_item_sos', 150000],
-        ['calc_item_customs_fee', 29592],
-        ['calc_item_broker_service', 90000],
+        ['calc_item_epts', fees.eptc],
+        ['calc_item_sbkts', fees.sbkts],
+        ['calc_item_sos', fees.sos],
+        ['calc_item_customs_fee', fees.customs_fee],
+        ['calc_item_broker_service', fees.broker_service],
 
         // ✅ СВХ по формуле
         ['calc_item_svh', svhSum],
@@ -360,10 +377,14 @@
         // ✅ Декларант на границе
         ['calc_item_border_broker', declarantSum],
 
-        // ✅ Дизель: 220л × цена
+        // ✅ Дизель + AdBlue
         ['calc_item_diesel_pack', dieselSum],
 
-        ['calc_item_red_corridor', 50000]
+        ['calc_item_red_corridor', fees.red_corridor],
+
+        ['calc_item_driver', fees.driver],
+        ['calc_item_insurance', fees.insurance],
+        ['calc_item_toll_road', fees.toll_road]
       ],
       delivery: [
         ['calc_item_delivery_city', 150000]
@@ -448,7 +469,7 @@
 
     const baseKZT = priceUSD * rate;
     const dutyKZT = baseKZT * DUTY;
-    const customsFee = 29592;
+    const customsFee = CALC_CONFIG.fees?.customs_fee || 25950;
     // ✅ Акциз (только легковые)
     let exciseKZT = 0;
     if (CURRENT_VEHICLE_PROFILE === "CAR") {

--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -196,6 +196,9 @@
       calc_item_diesel_pack: 'Солярка + AdBlue пакет',
       calc_item_red_corridor: '«Красный коридор»',
       calc_item_thanks_astana: '«Спасибо Астане»',
+      calc_item_driver: 'Водитель',
+      calc_item_insurance: 'Страховка',
+      calc_item_toll_road: 'Платная дорога',
 
       calc_item_declaration: 'Декларация о соответствии',
       calc_item_customs_broker: 'Таможенный брокер',
@@ -408,6 +411,9 @@
       calc_item_diesel_pack: 'Дизель + AdBlue пакеті',
       calc_item_red_corridor: '«Қызыл дәліз»',
       calc_item_thanks_astana: '«Астанаға рахмет»',
+      calc_item_driver: 'Жүргізуші',
+      calc_item_insurance: 'Сақтандыру',
+      calc_item_toll_road: 'Ақылы жол',
 
       calc_item_declaration: 'Сәйкестік декларациясы',
       calc_item_customs_broker: 'Кедендік брокер',
@@ -619,6 +625,9 @@
       calc_item_diesel_pack: '柴油 + AdBlue 套餐',
       calc_item_red_corridor: '红色通道',
       calc_item_thanks_astana: '“感谢阿斯塔纳”',
+      calc_item_driver: '司机',
+      calc_item_insurance: '保险',
+      calc_item_toll_road: '收费公路',
 
       calc_item_declaration: '符合性声明',
       calc_item_customs_broker: '海关代理',
@@ -832,6 +841,9 @@
       calc_item_diesel_pack: 'Diesel + AdBlue package',
       calc_item_red_corridor: 'Red corridor',
       calc_item_thanks_astana: '“Thanks to Astana”',
+      calc_item_driver: 'Driver',
+      calc_item_insurance: 'Insurance',
+      calc_item_toll_road: 'Toll road',
 
       calc_item_declaration: 'Declaration of conformity',
       calc_item_customs_broker: 'Customs broker',

--- a/china-motors-site/kz_calc_config.json
+++ b/china-motors-site/kz_calc_config.json
@@ -5,7 +5,8 @@
     "cny_kzt": 68.5
   },
   "diesel": {
-    "price_kzt_per_l": 360
+    "price_kzt_per_l": 335,
+    "liters": 200
   },
   "mrp_by_year": {
     "2024": 3692,
@@ -18,7 +19,17 @@
   },
   "fees": {
     "plate": 16963,
-    "srtc": 17516
+    "srtc": 17516,
+    "eptc": 50000,
+    "sbkts": 150000,
+    "sos": 200000,
+    "customs_fee": 25950,
+    "broker_service": 90000,
+    "red_corridor": 450000,
+    "adblue": 13500,
+    "driver": 65000,
+    "insurance": 5000,
+    "toll_road": 9000
   },
   "duty_rules": {
     "SPECIAL": 0,


### PR DESCRIPTION
- kz_calc_config.json: update fees to match the uploaded таможенная очистка Excel (СБКТС, СОС, брокерская услуга, красный коридор, добавлены ЭПТС/водитель/страховка/платная дорога, скорректирован расход дизеля)
- calculator.js: getExpensePackage() now reads all amounts from CALC_CONFIG.fees instead of hardcoded numbers, fixes the swapped SBKTS/SOS values, folds AdBlue into the diesel line, adds ЭПТС and the delivery-related driver/insurance/toll-road line items; recalc() now uses CALC_CONFIG.fees.customs_fee for the VAT base instead of a stale hardcoded constant
- common.js: add ru/kk/zh/en translations for the 3 new calc_item keys