### PR TITLE
Simplify client-facing calculator: drop internal toggles, auto-fetch …

### DIFF
--- a/china-motors-site/calculator.html
+++ b/china-motors-site/calculator.html
@@ -297,18 +297,6 @@
           <h2 class="calc-card__title" data-i18n="calc_util_title">5) Утилизационный сбор и регистрация</h2>
           <div class="bill">
             <h4 data-i18n="calc_util_list_title">Государственные платежи</h4>
-            
-            <div class="calc-flags" style="margin-bottom:12px">
-              <label style="display:flex;gap:8px;align-items:center;cursor:pointer;font-weight:600">
-                <input type="checkbox" id="flagExcelMax">
-                <span data-i18n="calc_flag_excel_max">Режим Excel / максимум</span>
-              </label>
-              <label style="display:flex;gap:8px;align-items:center">
-                <input type="checkbox" id="flagExcludeBase">
-                <span data-i18n="calc_flag_exclude_base">Цена авто уже оплачена</span>
-              </label>
-
-            </div>
             <ul id="list-util"></ul>
 
           </div>

--- a/china-motors-site/js/calculator.js
+++ b/china-motors-site/js/calculator.js
@@ -496,7 +496,8 @@
     document.getElementById('vatOutKZT') &&
       (document.getElementById('vatOutKZT').textContent = fmt(vatKZT) + ' ₸');
 
-    const excelMax = document.getElementById('flagExcelMax')?.checked;
+    // Клиентский расчёт всегда показывает полную расшифровку расходов.
+    const excelMax = true;
 
     const pkg = getExpensePackage(
       CURRENT_VEHICLE_PROFILE,
@@ -655,10 +656,6 @@
       deliveryTotal +
       utilTotal;
 
-    if (document.getElementById('flagExcludeBase')?.checked) {
-      totalKZT -= baseKZT;
-    }
-
     $('#sTotalKZT').textContent = fmt(totalKZT) + ' ₸';
     $('#sTotalUSD').textContent = '≈ ' + fmt(totalKZT / rate) + ' USD';
     if ($('#sTotalCNY')) {
@@ -733,10 +730,6 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    updateNBKRate(false); // только показать, НЕ менять input
-  });
-
   document.addEventListener('langchange', recalc);
 
   function generateCalcId() {
@@ -785,7 +778,9 @@
     await loadCalcConfig();
     // Живые курсы нужны до prefillFromURL(), иначе перевод цены из юаней
     // в доллары (если товар пришёл с CNY-ценой) отработает на дефолтном курсе.
-    await updateNBKRate();
+    // updateInput:true — сразу подставляем живой курс в поле #rate, а не
+    // ждём, пока клиент сам нажмёт «Обновить курс».
+    await updateNBKRate({ updateInput: true });
     prefillFromURL();
     updateVehicleProfile();
     recalc(); // уже пересчитает с новым годом и весом
@@ -853,7 +848,6 @@
 
   }
 
-  document.getElementById('flagExcelMax')?.addEventListener('change', recalc);
   document.getElementById('btnRefreshRate')
     ?.addEventListener('click', () => {
       updateNBKRate({ updateInput: true, doRecalc: true });

--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -212,8 +212,6 @@
       calc_item_first_reg: 'Первичная регистрация',
       calc_item_srtc: 'Техпаспорт (СРТС)',
 
-      calc_flag_exclude_base: 'Цена авто уже оплачена',
-      calc_flag_excel_max: 'Расширенные расходы (служебно)',
 
       // TOTAL LABELS
       calc_total_vehicle: 'Стоимость авто',
@@ -426,8 +424,6 @@
       calc_item_util_tax: 'Утилизациялық алым',
       calc_item_first_reg: 'Бастапқы тіркеу',
       calc_item_srtc: 'Техникалық төлқұжат (СРТС)',
-      calc_flag_exclude_base: 'Көлік бағасы төленген',
-      calc_flag_excel_max: 'Кеңейтілген шығындар (қызметтік)',
 
       // TOTAL LABELS
       calc_total_vehicle: 'Көлік құны',
@@ -640,8 +636,6 @@
       calc_item_util_tax: '回收费',
       calc_item_first_reg: '首次注册',
       calc_item_srtc: '技术护照（SRTC）',
-      calc_flag_exclude_base: '车辆价格已支付',
-      calc_flag_excel_max: '扩展费用（内部）',
 
       // TOTAL LABELS
       calc_total_vehicle: '车辆价格',
@@ -856,8 +850,6 @@
       calc_item_util_tax: 'Recycling fee',
       calc_item_first_reg: 'Initial registration',
       calc_item_srtc: 'Technical passport (SRTC)',
-      calc_flag_exclude_base: 'Vehicle price already paid',
-      calc_flag_excel_max: 'Extended expenses (internal)',
 
       // TOTAL LABELS
       calc_total_vehicle: 'Vehicle price',


### PR DESCRIPTION
…live rate

- Removed the "Расширенные расходы (служебно)" / "Цена авто уже оплачена" checkboxes — they were internal/service toggles that confused clients. The calculator now always shows the full itemized breakdown and always includes the vehicle price in the total (previous default behaviour already matched this, so no output changes for the common case).
- Live USD/CNY rate now populates the #rate input automatically on page load (previously it only updated the informational text — the input itself stayed on the hardcoded 540 default until the user clicked "Обновить курс", meaning the calculation ran on a stale rate).
- Removed the now-unused i18n keys and the stray malformed updateNBKRate(false) call on DOMContentLoaded.