### PR TITLE
Stop zero-rating "спецтехника": duty, recycling fee and reg were wron…

### DIFF
--- a/china-motors-site/js/calculator.js
+++ b/china-motors-site/js/calculator.js
@@ -218,9 +218,6 @@
   }
 
   function getFirstRegRateByAge(age, profile, intl) {
-    // ✅ Спецтехника не платит первичную регистрацию
-    if (profile === "SPECIAL") return 0;
-
     // ✅ Прицепы не платят первичную регистрацию
     if (profile === "TRAILER") return 0;
 
@@ -255,23 +252,20 @@
     // коэффициент, а не коэффициент по своему curb weight).
     if (profile === "TRACTOR_N3") return 11.0;
 
-    if (weight <= 2.5) return 3.5;
-    if (weight <= 3.5) return 7.5;
-    if (weight <= 5)   return 7.5;
-    if (weight <= 8)   return 8.0;
-    if (weight <= 12)  return 9.5;
-    if (weight <= 20)  return 10.5;
-    return 20.5; // 20–50 т и выше (кроме тягачей)
+    // 🚚 Остальная тяжёлая техника (самосвалы, манипуляторы и т.д.):
+    // во ВСЕХ реальных счетах на растаможку утильсбор посчитан по
+    // максимальному разряду (20–50 т) независимо от указанного веса
+    // техники "по паспорту" (собственная масса 10–18 т в этих примерах) —
+    // сбор считается по полной/разрешённой массе, а не по массе тары.
+    // Весь наш каталог — тяжёлые грузовики этого класса, поэтому берём
+    // максимальный коэффициент всегда, а не по весовой сетке.
+    return 20.5;
   }
 
   function getUtilByWeight2026(weight, profile) {
     if (!weight) return 0;
     // ✅ Прицепы и полуприцепы — утильсбор не применяется
     if (profile === "TRAILER") {
-      return 0;
-    }
-    // ✅ Спецтехника — утильсбор не применяется
-    if (profile === "SPECIAL") {
       return 0;
     }
 
@@ -301,10 +295,11 @@
       return 0;
     }
 
-    // ✅ Спецтехника (вышка, манипулятор, миксер и т.д.) = 0%
-    if (profile === "SPECIAL") {
-      return 0;
-    }
+    // ⚠️ Остальная "спецтехника" (манипулятор, автовышка, миксер и т.д.) —
+    // по факту это грузовик с надстройкой, таможня облагает пошлиной как
+    // обычный грузовой (ТНВЭД 8704, не спецмашина) — подтверждено реальным
+    // счётом на манипулятор (10% пошлины, не 0%). Раньше здесь стояло
+    // ошибочное освобождение всего профиля SPECIAL от пошлины.
 
     if (t.includes("кран")) {
       return CALC_CONFIG.duty_rules?.CRANE || 0.08;
@@ -330,7 +325,7 @@
    PACKAGES (as in Excel)
    ========================================================= */
 
-  function getExpensePackage(profile, excelMax, rate) {
+  function getExpensePackage(profile, rate) {
     const fees = CALC_CONFIG.fees;
 
     // Дизель и AdBlue — отдельные строки (как в реальных счетах на растаможку)
@@ -347,20 +342,6 @@
     // (прицепы отдельно не учитываются, для них своей формулы пока нет)
     const svhSum = (profile === "TRAILER") ? 0 : (fees.svh || 91000);
 
-    // Пока делаем для грузовых / тягачей
-    if (!excelMax) {
-      return {
-        mandatory: [
-          ['calc_item_customs_fee', fees.customs_fee],
-          ['calc_item_broker_service', fees.broker_service]
-        ],
-        delivery: [
-          ['calc_item_delivery_city', 150000]
-        ]
-      };
-    }
-
-    // Excel / максимум
     return {
       mandatory: [
         ['calc_item_epts', fees.eptc],
@@ -375,18 +356,21 @@
         // ✅ Декларант на границе
         ['calc_item_border_broker', declarantSum],
 
-        // ✅ Дизель и AdBlue отдельными строками
+        ['calc_item_red_corridor', fees.red_corridor]
+      ],
+      // ✅ Реальная "доставка" — это водитель, топливо, страховка, платная
+      // дорога (ровно так эти статьи сгруппированы в v32fix_work и в реальных
+      // счетах на растаможку). Раньше здесь стояла ОТДЕЛЬНАЯ фиктивная строка
+      // "Доставка до Алматы/лаборатории/СВХ" 150 000 ₸ — в реальных счетах
+      // такой отдельной строки нет, её сумма нигде не встречается: итог
+      // расходов там полностью и без остатка складывается именно из этих
+      // пяти статей. Оставляли бы её — клиент платил бы дважды за доставку.
+      delivery: [
+        ['calc_item_driver', fees.driver],
         ['calc_item_diesel', dieselSum],
         ['calc_item_adblue', adblueSum],
-
-        ['calc_item_red_corridor', fees.red_corridor],
-
-        ['calc_item_driver', fees.driver],
         ['calc_item_insurance', fees.insurance],
         ['calc_item_toll_road', fees.toll_road]
-      ],
-      delivery: [
-        ['calc_item_delivery_city', 150000]
       ]
     };
   }
@@ -496,14 +480,7 @@
     document.getElementById('vatOutKZT') &&
       (document.getElementById('vatOutKZT').textContent = fmt(vatKZT) + ' ₸');
 
-    // Клиентский расчёт всегда показывает полную расшифровку расходов.
-    const excelMax = true;
-
-    const pkg = getExpensePackage(
-      CURRENT_VEHICLE_PROFILE,
-      excelMax,
-      rate
-    );
+    const pkg = getExpensePackage(CURRENT_VEHICLE_PROFILE, rate);
 
     // --- 3) Дополнительные расходы ---
     const mandatoryList = document.getElementById('list-mandatory');
@@ -574,21 +551,15 @@
 
     }
 
-    // ✅ Госномер: только грузовые и тягачи
+    // ✅ Госномер: все, кроме прицепов
     let plateSum = 0;
-    if (
-      CURRENT_VEHICLE_PROFILE !== "SPECIAL" &&
-      CURRENT_VEHICLE_PROFILE !== "TRAILER"
-    ) {
+    if (CURRENT_VEHICLE_PROFILE !== "TRAILER") {
       plateSum = CALC_CONFIG.fees.plate;
     }
 
-    // ✅ СРТС: только грузовые и тягачи
+    // ✅ СРТС: все, кроме прицепов
     let srtcSum = 0;
-    if (
-      CURRENT_VEHICLE_PROFILE !== "SPECIAL" &&
-      CURRENT_VEHICLE_PROFILE !== "TRAILER"
-    ) {
+    if (CURRENT_VEHICLE_PROFILE !== "TRAILER") {
       srtcSum = CALC_CONFIG.fees.srtc || 0;
     }
 
@@ -664,14 +635,6 @@
 
     $('#mandatoryTotal') && ($('#mandatoryTotal').textContent = fmt(mandatoryTotal));
     $('#deliveryTotal') && ($('#deliveryTotal').textContent = fmt(deliveryTotal));
-    console.log('EXCEL MODE CHECK:', excelMax);
-    console.log('BASE KZT:', baseKZT);
-    console.log("TOTAL =", totalKZT);
-
-    const out = document.getElementById("sTotalKZT");
-    console.log("ELEMENT =", out);
-
-
   }
   // nationalbank.kz не отдаёт CORS-заголовки, поэтому браузер не может
   // сходить туда напрямую — курсы берём через бэкенд, который проксирует

--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -202,7 +202,6 @@
 
       calc_item_declaration: 'Декларация о соответствии',
       calc_item_customs_broker: 'Таможенный брокер',
-      calc_item_delivery_city: 'Доставка до Алматы/лаборатории/СВХ',
       calc_item_driver: 'Водитель',
       calc_item_adblue: 'AdBlue',
       calc_item_toll_road: 'Платная дорога',
@@ -415,7 +414,6 @@
 
       calc_item_declaration: 'Сәйкестік декларациясы',
       calc_item_customs_broker: 'Кедендік брокер',
-      calc_item_delivery_city: 'Алматы/лаборатория/СВХ-ға жеткізу',
       calc_item_driver: 'Жүргізуші',
       calc_item_adblue: 'AdBlue',
       calc_item_toll_road: 'Ақылы жол',
@@ -627,7 +625,6 @@
 
       calc_item_declaration: '符合性声明',
       calc_item_customs_broker: '海关代理',
-      calc_item_delivery_city: '送货至阿拉木图/实验室/仓储区',
       calc_item_driver: '司机',
       calc_item_adblue: 'AdBlue',
       calc_item_toll_road: '收费公路',
@@ -841,7 +838,6 @@
 
       calc_item_declaration: 'Declaration of conformity',
       calc_item_customs_broker: 'Customs broker',
-      calc_item_delivery_city: 'Delivery to Almaty/lab/SVH',
       calc_item_driver: 'Driver',
       calc_item_adblue: 'AdBlue',
       calc_item_toll_road: 'Toll road',


### PR DESCRIPTION
…gly free

Real customs invoice for a Shacman manipulator/crane truck (профиль "Спецтехника" in the calculator) showed standard 10% duty, a full recycling fee, and primary registration — none of which our calculator charged, because profile === "SPECIAL" short-circuited all three to 0. A truck with a mounted crane/manipulator is still customs-classified as a regular cargo truck (ТНВЭД 8704), not exempt spec machinery — only the narrow keyword-matched cases (tracked excavator, front-end loader) are genuinely duty-free, and those checks already existed separately.

- getDutyRate/getUtilByWeight2026/getFirstRegRateByAge: removed the blanket "profile === SPECIAL → 0" rules; SPECIAL now gets the same treatment as a regular truck unless a specific keyword exemption applies
- Госномер/СРТС now charged for SPECIAL too (previously skipped)
- Recycling-fee weight table replaced with a flat top-bracket coefficient for all non-tractor heavy trucks — every real invoice example (manipulator + 2 dump trucks) landed in the max bracket regardless of the vehicle's curb weight, so the fee is evidently based on permissible max mass, not curb weight, for this fleet
- getExpensePackage: removed the flat "Доставка до Алматы/лаборатории/ СВХ" 150 000 ₸ line — it doesn't exist in any real invoice and duplicated driver+diesel+AdBlue+insurance+toll, which are already billed individually. Moved those five items into the "delivery" group to match how v32fix_work and the real invoices categorize them.
- Dropped leftover debug console.log calls and the now-unused excelMax parameter/branch (always true after the previous simplification)