### PR TITLE
Add international carrier permit checkbox for tractors

### DIFF
--- a/china-motors-site/calculator.html
+++ b/china-motors-site/calculator.html
@@ -175,6 +175,15 @@
             </div>
             <hr />
 
+            <!-- ✅ Международный перевозчик (только для тягачей) -->
+            <div id="tractorBlock" style="display:none; margin-bottom:10px;">
+              <label style="display:flex;gap:8px;align-items:center;cursor:pointer">
+                <input type="checkbox" id="flagIntlCarrier" checked />
+                <span data-i18n="calc_flag_intl_carrier">Есть удостоверение международного перевозчика (первичная регистрация не взимается для тягачей до 7 лет)</span>
+              </label>
+            </div>
+            <!-- ✅ конец tractorBlock -->
+
             <!-- ✅ Hybrid block (только для легковых) -->
             <div id="hybridBlock" style="display:none;">
 

--- a/china-motors-site/js/calculator.js
+++ b/china-motors-site/js/calculator.js
@@ -446,10 +446,14 @@
     const mrp = getCurrentMRP();
 
     // ✅ правильная ставка первички
+    // Чекбокс "есть удостоверение международного перевозчика" — по
+    // умолчанию включён (checked в HTML), т.к. в большинстве случаев он
+    // у клиентов есть; актуален только для тягачей (см. toggleTractorBlock).
+    const intlCarrier = document.getElementById('flagIntlCarrier')?.checked ?? URL_PARAMS.intl;
     const firstRegRate = getFirstRegRateByAge(
       vehicleAge,
       CURRENT_VEHICLE_PROFILE,
-      URL_PARAMS.intl
+      intlCarrier
     );
 
 
@@ -754,6 +758,7 @@
     await updateNBKRate({ updateInput: true });
     prefillFromURL();
     updateVehicleProfile();
+    toggleTractorBlock();
     recalc(); // уже пересчитает с новым годом и весом
     // ✅ показать hybridBlock сразу при загрузке
     const isCar = document.getElementById("type").value === "CAR";
@@ -813,10 +818,20 @@
         document.getElementById("hybridFields").style.display = "none";
       }
 
+      toggleTractorBlock();
+
       recalc();
     });
 
 
+  }
+
+  // Чекбокс "удостоверение международного перевозчика" актуален только
+  // для тягачей (N3) — для остальных типов техники он не влияет на расчёт.
+  function toggleTractorBlock() {
+    const isTractor = document.getElementById("type")?.value === "TRACTOR_N3";
+    const box = document.getElementById("tractorBlock");
+    if (box) box.style.display = isTractor ? "block" : "none";
   }
 
   document.getElementById('btnRefreshRate')

--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -210,6 +210,7 @@
       calc_item_util_tax: 'Утилизационный сбор',
       calc_item_first_reg: 'Первичная регистрация',
       calc_item_srtc: 'Техпаспорт (СРТС)',
+      calc_flag_intl_carrier: 'Есть удостоверение международного перевозчика (первичная регистрация не взимается для тягачей до 7 лет)',
 
 
       // TOTAL LABELS
@@ -422,6 +423,7 @@
       calc_item_util_tax: 'Утилизациялық алым',
       calc_item_first_reg: 'Бастапқы тіркеу',
       calc_item_srtc: 'Техникалық төлқұжат (СРТС)',
+      calc_flag_intl_carrier: 'Халықаралық тасымалдаушы куәлігі бар (тартқыштар үшін 7 жасқа дейін бастапқы тіркеу алынбайды)',
 
       // TOTAL LABELS
       calc_total_vehicle: 'Көлік құны',
@@ -633,6 +635,7 @@
       calc_item_util_tax: '回收费',
       calc_item_first_reg: '首次注册',
       calc_item_srtc: '技术护照（SRTC）',
+      calc_flag_intl_carrier: '持有国际承运人证书（7年以内牵引车免收首次注册费）',
 
       // TOTAL LABELS
       calc_total_vehicle: '车辆价格',
@@ -846,6 +849,7 @@
       calc_item_util_tax: 'Recycling fee',
       calc_item_first_reg: 'Initial registration',
       calc_item_srtc: 'Technical passport (SRTC)',
+      calc_flag_intl_carrier: 'Has international carrier permit (primary registration waived for tractors under 7 years old)',
 
       // TOTAL LABELS
       calc_total_vehicle: 'Vehicle price',


### PR DESCRIPTION
Previously the "удостоверение международного перевозчика" exemption (waives primary registration for N3 tractors under 7 years old) was only reachable via an undocumented ?intl=1 URL param. Added a visible checkbox, checked by default (most clients have this permit), shown only when "Тягач" is selected in the type dropdown.