### PR TITLE
Add customer registration/login pages (stage 1 of role system)

### DIFF
--- a/china-motors-site/calculator.html
+++ b/china-motors-site/calculator.html
@@ -343,6 +343,7 @@
   <div id="siteFooter"></div>
 
   <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
   <script src="js/calculator.js?v=2026-02-01"></script>
 
 </body>

--- a/china-motors-site/catalog.html
+++ b/china-motors-site/catalog.html
@@ -107,6 +107,7 @@
   <div id="siteFooter"></div>
 
   <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
   <script src="js/catalog.js"></script>
 </body>
 </html>

--- a/china-motors-site/contacts.html
+++ b/china-motors-site/contacts.html
@@ -61,6 +61,7 @@
   </section>
   <div id="siteFooter"></div>
   <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
   <script src="js/contacts.js"></script>
 
 </body>

--- a/china-motors-site/index.html
+++ b/china-motors-site/index.html
@@ -221,5 +221,6 @@
   <div id="siteFooter"></div>
 
   <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
 </body>
 </html>

--- a/china-motors-site/js/auth.js
+++ b/china-motors-site/js/auth.js
@@ -1,0 +1,80 @@
+// js/auth.js — регистрация/вход (физ. лицо / юр. лицо), JWT в localStorage
+(function () {
+  const metaBase = document.querySelector('meta[name="api-base"]')?.content?.trim();
+  const isLocal = /^(localhost|127\.0\.0\.1)$/.test(location.hostname);
+  const API_BASE = (metaBase || (isLocal ? 'http://127.0.0.1:8000' : 'https://cm-backend-daniyal.fly.dev'))
+    .replace(/\/+$/, '');
+
+  const LS_ACCESS = 'cm_access';
+  const LS_REFRESH = 'cm_refresh';
+  const LS_ROLE = 'cm_role';
+  const LS_VERIFIED = 'cm_verified';
+
+  function saveSession({ access, refresh, role, is_verified }) {
+    if (access) localStorage.setItem(LS_ACCESS, access);
+    if (refresh) localStorage.setItem(LS_REFRESH, refresh);
+    if (role) localStorage.setItem(LS_ROLE, role);
+    localStorage.setItem(LS_VERIFIED, is_verified ? '1' : '0');
+  }
+
+  function clearSession() {
+    localStorage.removeItem(LS_ACCESS);
+    localStorage.removeItem(LS_REFRESH);
+    localStorage.removeItem(LS_ROLE);
+    localStorage.removeItem(LS_VERIFIED);
+  }
+
+  function getSession() {
+    const access = localStorage.getItem(LS_ACCESS);
+    if (!access) return null;
+    return {
+      access,
+      refresh: localStorage.getItem(LS_REFRESH),
+      role: localStorage.getItem(LS_ROLE),
+      isVerified: localStorage.getItem(LS_VERIFIED) === '1',
+    };
+  }
+
+  async function apiPost(path, body) {
+    const res = await fetch(`${API_BASE}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const firstError = Object.values(data)[0];
+      const message = Array.isArray(firstError) ? firstError[0] : (data.detail || 'Ошибка запроса');
+      throw new Error(message);
+    }
+    return data;
+  }
+
+  async function registerPerson({ phone, password, fullName, iin }) {
+    const data = await apiPost('/api/auth/register/person/', {
+      phone, password, full_name: fullName, iin,
+    });
+    saveSession(data);
+    return data;
+  }
+
+  async function registerCompany({ phone, password, companyName, bin, address }) {
+    const data = await apiPost('/api/auth/register/company/', {
+      phone, password, company_name: companyName, bin, address,
+    });
+    saveSession(data);
+    return data;
+  }
+
+  async function login({ phone, password }) {
+    const data = await apiPost('/api/auth/login/', { phone, password });
+    saveSession(data);
+    return data;
+  }
+
+  function logout() {
+    clearSession();
+  }
+
+  window.CMAuth = { API_BASE, registerPerson, registerCompany, login, logout, getSession };
+})();

--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -13,6 +13,34 @@
       nav_services: 'Услуги',
       nav_contacts: 'Контакты',
       nav_calculator: 'Калькулятор',
+      nav_login: 'Войти',
+      nav_account: 'Личный кабинет',
+      nav_not_verified: 'не подтверждён',
+      nav_logout_confirm: 'Выйти из аккаунта?',
+      title_register: 'China Motors - Регистрация',
+      title_login: 'China Motors - Вход',
+      register_hero: 'Регистрация',
+      register_tagline: 'Создайте аккаунт клиента China Motors',
+      register_tab_person: 'Физ. лицо',
+      register_tab_company: 'Юр. лицо',
+      register_person_note: 'Физ. лицо может приобрести легковой автомобиль. Для коммерческой техники используйте регистрацию юр. лица.',
+      register_company_note: 'Юр. лица могут приобретать коммерческую технику разных видов.',
+      register_phone_label: 'Телефон',
+      register_password_label: 'Пароль',
+      register_fullname_label: 'ФИО',
+      register_iin_label: 'ИИН (для договора)',
+      register_companyname_label: 'Название компании',
+      register_bin_label: 'БИН (для договора)',
+      register_address_label: 'Юридический адрес',
+      register_submit: 'Создать аккаунт',
+      register_have_account: 'Уже есть аккаунт? Войти',
+      register_err_required: 'Заполните обязательные поля',
+      register_success: 'Регистрация завершена! Аккаунт ожидает подтверждения администратором.',
+      login_hero: 'Вход',
+      login_tagline: 'Войдите в личный кабинет China Motors',
+      login_submit: 'Войти',
+      login_no_account: 'Нет аккаунта? Зарегистрироваться',
+      login_success: 'Вход выполнен!',
 
       // COMMON
       brand_title: 'China Motors',
@@ -238,6 +266,34 @@
       nav_services: 'Қызметтер',
       nav_contacts: 'Байланыс',
       nav_calculator: 'Калькулятор',
+      nav_login: 'Кіру',
+      nav_account: 'Жеке кабинет',
+      nav_not_verified: 'расталмаған',
+      nav_logout_confirm: 'Аккаунттан шығу керек пе?',
+      title_register: 'China Motors - Тіркелу',
+      title_login: 'China Motors - Кіру',
+      register_hero: 'Тіркелу',
+      register_tagline: 'China Motors клиент аккаунтын жасаңыз',
+      register_tab_person: 'Жеке тұлға',
+      register_tab_company: 'Заңды тұлға',
+      register_person_note: 'Жеке тұлға жеңіл автокөлік сатып ала алады. Коммерциялық техника үшін заңды тұлға ретінде тіркеліңіз.',
+      register_company_note: 'Заңды тұлғалар әртүрлі коммерциялық техниканы сатып ала алады.',
+      register_phone_label: 'Телефон',
+      register_password_label: 'Құпия сөз',
+      register_fullname_label: 'Аты-жөні',
+      register_iin_label: 'ЖСН (келісімшарт үшін)',
+      register_companyname_label: 'Компания атауы',
+      register_bin_label: 'БСН (келісімшарт үшін)',
+      register_address_label: 'Заңды мекенжай',
+      register_submit: 'Аккаунт жасау',
+      register_have_account: 'Аккаунтыңыз бар ма? Кіру',
+      register_err_required: 'Міндетті өрістерді толтырыңыз',
+      register_success: 'Тіркелу аяқталды! Аккаунт әкімші растауын күтуде.',
+      login_hero: 'Кіру',
+      login_tagline: 'China Motors жеке кабинетіне кіріңіз',
+      login_submit: 'Кіру',
+      login_no_account: 'Аккаунтыңыз жоқ па? Тіркелу',
+      login_success: 'Кіру сәтті өтті!',
 
       brand_title: 'China Motors',
       hero_title_main: 'China Motors',
@@ -450,6 +506,34 @@
       nav_services: '服务',
       nav_contacts: '联系',
       nav_calculator: '计算器',
+      nav_login: '登录',
+      nav_account: '个人中心',
+      nav_not_verified: '未验证',
+      nav_logout_confirm: '确定要退出登录吗？',
+      title_register: 'China Motors - 注册',
+      title_login: 'China Motors - 登录',
+      register_hero: '注册',
+      register_tagline: '创建 China Motors 客户账户',
+      register_tab_person: '个人',
+      register_tab_company: '公司',
+      register_person_note: '个人可以购买乘用车。购买商用车请使用公司注册。',
+      register_company_note: '公司可以购买各种商用车辆。',
+      register_phone_label: '电话',
+      register_password_label: '密码',
+      register_fullname_label: '姓名',
+      register_iin_label: '身份识别号（IIN，用于合同）',
+      register_companyname_label: '公司名称',
+      register_bin_label: '商业识别号（BIN，用于合同）',
+      register_address_label: '法定地址',
+      register_submit: '创建账户',
+      register_have_account: '已有账户？登录',
+      register_err_required: '请填写必填项',
+      register_success: '注册完成！账户正在等待管理员验证。',
+      login_hero: '登录',
+      login_tagline: '登录您的 China Motors 个人中心',
+      login_submit: '登录',
+      login_no_account: '没有账户？注册',
+      login_success: '登录成功！',
 
       brand_title: 'China Motors',
       hero_title_main: 'China Motors',
@@ -662,6 +746,34 @@
       nav_services: 'Services',
       nav_contacts: 'Contacts',
       nav_calculator: 'Calculator',
+      nav_login: 'Log in',
+      nav_account: 'Account',
+      nav_not_verified: 'not verified',
+      nav_logout_confirm: 'Log out of your account?',
+      title_register: 'China Motors - Register',
+      title_login: 'China Motors - Login',
+      register_hero: 'Register',
+      register_tagline: 'Create a China Motors customer account',
+      register_tab_person: 'Individual',
+      register_tab_company: 'Company',
+      register_person_note: 'Individuals can purchase a passenger car. For commercial vehicles, please register as a company.',
+      register_company_note: 'Companies can purchase various types of commercial vehicles.',
+      register_phone_label: 'Phone',
+      register_password_label: 'Password',
+      register_fullname_label: 'Full name',
+      register_iin_label: 'IIN (for the contract)',
+      register_companyname_label: 'Company name',
+      register_bin_label: 'BIN (for the contract)',
+      register_address_label: 'Legal address',
+      register_submit: 'Create account',
+      register_have_account: 'Already have an account? Log in',
+      register_err_required: 'Please fill in the required fields',
+      register_success: 'Registration complete! Your account is awaiting admin verification.',
+      login_hero: 'Login',
+      login_tagline: 'Log in to your China Motors account',
+      login_submit: 'Log in',
+      login_no_account: "Don't have an account? Register",
+      login_success: 'Logged in successfully!',
 
       brand_title: 'China Motors',
       hero_title_main: 'China Motors',
@@ -956,6 +1068,38 @@
     });
   }
 
+  // Показывает «Войти» или «Личный кабинет» в шапке — зависит от того,
+  // залогинен ли клиент (js/auth.js, если подключён на странице).
+  function initAuthNav() {
+    const link = document.getElementById('navAuthLink');
+    if (!link || !window.CMAuth) return;
+
+    const session = window.CMAuth.getSession();
+    const label = link.querySelector('span');
+
+    if (session) {
+      link.href = '#';
+      if (label) label.setAttribute('data-i18n', 'nav_account');
+      label.textContent = session.isVerified
+        ? window.t('nav_account')
+        : `${window.t('nav_account')} (${window.t('nav_not_verified')})`;
+      link.onclick = (e) => {
+        e.preventDefault();
+        if (confirm(window.t('nav_logout_confirm'))) {
+          window.CMAuth.logout();
+          location.reload();
+        }
+      };
+    } else {
+      link.href = 'login.html';
+      if (label) {
+        label.setAttribute('data-i18n', 'nav_login');
+        label.textContent = window.t('nav_login');
+      }
+      link.onclick = null;
+    }
+  }
+
   /* =====================
      PARTIAL LOADER
      ===================== */
@@ -977,6 +1121,7 @@
     initTheme();
     initLang();
     initBurger();
+    initAuthNav();
   });
 
 

--- a/china-motors-site/js/login.js
+++ b/china-motors-site/js/login.js
@@ -1,0 +1,34 @@
+// js/login.js
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('formLogin');
+  const statusEl = document.getElementById('loginStatus');
+  const btn = document.getElementById('btnLogin');
+
+  function showStatus(message, isError) {
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.className = isError ? 'error' : 'success';
+    statusEl.style.display = 'block';
+  }
+
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const phone = document.getElementById('l-phone').value.trim();
+    const password = document.getElementById('l-password').value;
+
+    if (!phone || !password) {
+      showStatus(t('register_err_required'), true);
+      return;
+    }
+
+    btn.disabled = true;
+    try {
+      await window.CMAuth.login({ phone, password });
+      showStatus(t('login_success'), false);
+      setTimeout(() => { location.href = 'index.html'; }, 1000);
+    } catch (err) {
+      showStatus(err.message, true);
+      btn.disabled = false;
+    }
+  });
+});

--- a/china-motors-site/js/register.js
+++ b/china-motors-site/js/register.js
@@ -1,0 +1,79 @@
+// js/register.js — переключение форм физ./юр. лицо + отправка на бэкенд
+document.addEventListener('DOMContentLoaded', () => {
+  const tabPerson = document.getElementById('tabPerson');
+  const tabCompany = document.getElementById('tabCompany');
+  const formPerson = document.getElementById('formPerson');
+  const formCompany = document.getElementById('formCompany');
+
+  tabPerson?.addEventListener('click', () => {
+    tabPerson.classList.add('active');
+    tabCompany.classList.remove('active');
+    formPerson.style.display = '';
+    formCompany.style.display = 'none';
+  });
+
+  tabCompany?.addEventListener('click', () => {
+    tabCompany.classList.add('active');
+    tabPerson.classList.remove('active');
+    formCompany.style.display = '';
+    formPerson.style.display = 'none';
+  });
+
+  function showStatus(el, message, isError) {
+    if (!el) return;
+    el.textContent = message;
+    el.className = isError ? 'error' : 'success';
+    el.style.display = 'block';
+  }
+
+  formPerson?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const btn = document.getElementById('btnRegisterPerson');
+    const statusEl = document.getElementById('personStatus');
+    const phone = document.getElementById('p-phone').value.trim();
+    const password = document.getElementById('p-password').value;
+    const fullName = document.getElementById('p-fullname').value.trim();
+    const iin = document.getElementById('p-iin').value.trim();
+
+    if (!phone || !password) {
+      showStatus(statusEl, t('register_err_required'), true);
+      return;
+    }
+
+    btn.disabled = true;
+    try {
+      await window.CMAuth.registerPerson({ phone, password, fullName, iin });
+      showStatus(statusEl, t('register_success'), false);
+      setTimeout(() => { location.href = 'index.html'; }, 1500);
+    } catch (err) {
+      showStatus(statusEl, err.message, true);
+      btn.disabled = false;
+    }
+  });
+
+  formCompany?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const btn = document.getElementById('btnRegisterCompany');
+    const statusEl = document.getElementById('companyStatus');
+    const phone = document.getElementById('c-phone').value.trim();
+    const password = document.getElementById('c-password').value;
+    const companyName = document.getElementById('c-companyname').value.trim();
+    const bin = document.getElementById('c-bin').value.trim();
+    const address = document.getElementById('c-address').value.trim();
+
+    if (!phone || !password || !companyName) {
+      showStatus(statusEl, t('register_err_required'), true);
+      return;
+    }
+
+    btn.disabled = true;
+    try {
+      await window.CMAuth.registerCompany({ phone, password, companyName, bin, address });
+      showStatus(statusEl, t('register_success'), false);
+      setTimeout(() => { location.href = 'index.html'; }, 1500);
+    } catch (err) {
+      showStatus(statusEl, err.message, true);
+      btn.disabled = false;
+    }
+  });
+});

--- a/china-motors-site/login.html
+++ b/china-motors-site/login.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta name="api-base" content="https://cm-backend-daniyal.fly.dev">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Вход в личный кабинет China Motors">
+
+  <meta name="theme-color" content="#0b2b5a">
+  <link rel="icon" href="/icons/icon-192.png">
+  <link rel="apple-touch-icon" href="/icons/icon-192.png">
+
+  <title data-i18n="title_login">China Motors - Вход</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Montserrat:wght@600&family=Oswald:wght@500&family=Open+Sans:wght@400;700&family=Poppins:wght@500;600&subset=cyrillic-ext&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+
+  <style>
+    .auth-link {
+      display: block;
+      text-align: center;
+      margin-top: 10px;
+    }
+  </style>
+</head>
+<body>
+  <div id="siteHeader"></div>
+
+  <section class="hero section fade-in">
+    <div class="container">
+      <div class="hero-overlay">
+        <h1 data-i18n="login_hero">Вход</h1>
+        <p class="White-p" data-i18n="login_tagline">Войдите в личный кабинет China Motors</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section fade-in">
+    <div class="container">
+      <form id="formLogin" class="contact-form">
+        <label for="l-phone" data-i18n="register_phone_label">Телефон</label>
+        <input type="tel" id="l-phone" data-i18n-placeholder="contact_phone_ph" placeholder="+7 (___) ___-__-__" required>
+
+        <label for="l-password" data-i18n="register_password_label">Пароль</label>
+        <input type="password" id="l-password" required>
+
+        <button type="submit" class="btn" id="btnLogin">
+          <i class="fas fa-right-to-bracket"></i> <span data-i18n="login_submit">Войти</span>
+        </button>
+
+        <div id="loginStatus"></div>
+      </form>
+
+      <a class="auth-link" href="register.html" data-i18n="login_no_account">Нет аккаунта? Зарегистрироваться</a>
+    </div>
+  </section>
+
+  <div id="siteFooter"></div>
+  <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/login.js"></script>
+</body>
+</html>

--- a/china-motors-site/partials/navbar.html
+++ b/china-motors-site/partials/navbar.html
@@ -18,6 +18,11 @@
     <!-- RIGHT -->
     <div class="nav-right">
 
+      <!-- Auth (Войти / Личный кабинет) -->
+      <a id="navAuthLink" href="login.html" class="nav-auth-link">
+        <i class="fas fa-right-to-bracket"></i> <span data-i18n="nav_login">Войти</span>
+      </a>
+
       <!-- Theme toggle -->
       <button id="themeToggle" class="theme-toggle" aria-label="Theme">
         <span class="icon sun"><i class="fa-solid fa-sun"></i></span>

--- a/china-motors-site/privacy-policy.html
+++ b/china-motors-site/privacy-policy.html
@@ -95,5 +95,6 @@
   <div id="siteFooter"></div>
 
   <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
 </body>
 </html>

--- a/china-motors-site/product.html
+++ b/china-motors-site/product.html
@@ -249,6 +249,7 @@
 
 <!-- scripts -->
 <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
 <script src="js/product.js"></script>
 
 </body>

--- a/china-motors-site/register.html
+++ b/china-motors-site/register.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta name="api-base" content="https://cm-backend-daniyal.fly.dev">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Регистрация клиента China Motors — физическое или юридическое лицо">
+
+  <meta name="theme-color" content="#0b2b5a">
+  <link rel="icon" href="/icons/icon-192.png">
+  <link rel="apple-touch-icon" href="/icons/icon-192.png">
+
+  <title data-i18n="title_register">China Motors - Регистрация</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Montserrat:wght@600&family=Oswald:wght@500&family=Open+Sans:wght@400;700&family=Poppins:wght@500;600&subset=cyrillic-ext&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+
+  <style>
+    .auth-toggle {
+      display: flex;
+      gap: 10px;
+      max-width: 600px;
+      margin: 0 auto 20px;
+    }
+    .auth-toggle button {
+      flex: 1;
+      padding: 12px;
+      border-radius: 8px;
+      border: 2px solid var(--primary-blue);
+      background: transparent;
+      color: var(--primary-blue);
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .auth-toggle button.active {
+      background: var(--primary-blue);
+      color: #fff;
+    }
+    .auth-note {
+      max-width: 600px;
+      margin: 0 auto 16px;
+      opacity: .8;
+      font-size: 14px;
+    }
+    .auth-link {
+      display: block;
+      text-align: center;
+      margin-top: 10px;
+    }
+  </style>
+</head>
+<body>
+  <div id="siteHeader"></div>
+
+  <section class="hero section fade-in">
+    <div class="container">
+      <div class="hero-overlay">
+        <h1 data-i18n="register_hero">Регистрация</h1>
+        <p class="White-p" data-i18n="register_tagline">Создайте аккаунт клиента China Motors</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section fade-in">
+    <div class="container">
+
+      <div class="auth-toggle">
+        <button id="tabPerson" class="active" data-i18n="register_tab_person">Физ. лицо</button>
+        <button id="tabCompany" data-i18n="register_tab_company">Юр. лицо</button>
+      </div>
+
+      <!-- ФИЗ. ЛИЦО -->
+      <form id="formPerson" class="contact-form">
+        <p class="auth-note" data-i18n="register_person_note">Физ. лицо может приобрести легковой автомобиль. Для коммерческой техники используйте регистрацию юр. лица.</p>
+
+        <label for="p-phone" data-i18n="register_phone_label">Телефон</label>
+        <input type="tel" id="p-phone" data-i18n-placeholder="contact_phone_ph" placeholder="+7 (___) ___-__-__" required>
+
+        <label for="p-password" data-i18n="register_password_label">Пароль</label>
+        <input type="password" id="p-password" required>
+
+        <label for="p-fullname" data-i18n="register_fullname_label">ФИО</label>
+        <input type="text" id="p-fullname">
+
+        <label for="p-iin" data-i18n="register_iin_label">ИИН (для договора)</label>
+        <input type="text" id="p-iin">
+
+        <button type="submit" class="btn" id="btnRegisterPerson">
+          <i class="fas fa-user-plus"></i> <span data-i18n="register_submit">Создать аккаунт</span>
+        </button>
+
+        <div id="personStatus"></div>
+      </form>
+
+      <!-- ЮР. ЛИЦО -->
+      <form id="formCompany" class="contact-form" style="display:none">
+        <p class="auth-note" data-i18n="register_company_note">Юр. лица могут приобретать коммерческую технику разных видов.</p>
+
+        <label for="c-phone" data-i18n="register_phone_label">Телефон</label>
+        <input type="tel" id="c-phone" data-i18n-placeholder="contact_phone_ph" placeholder="+7 (___) ___-__-__" required>
+
+        <label for="c-password" data-i18n="register_password_label">Пароль</label>
+        <input type="password" id="c-password" required>
+
+        <label for="c-companyname" data-i18n="register_companyname_label">Название компании</label>
+        <input type="text" id="c-companyname" required>
+
+        <label for="c-bin" data-i18n="register_bin_label">БИН (для договора)</label>
+        <input type="text" id="c-bin">
+
+        <label for="c-address" data-i18n="register_address_label">Юридический адрес</label>
+        <input type="text" id="c-address">
+
+        <button type="submit" class="btn" id="btnRegisterCompany">
+          <i class="fas fa-building"></i> <span data-i18n="register_submit">Создать аккаунт</span>
+        </button>
+
+        <div id="companyStatus"></div>
+      </form>
+
+      <a class="auth-link" href="login.html" data-i18n="register_have_account">Уже есть аккаунт? Войти</a>
+
+    </div>
+  </section>
+
+  <div id="siteFooter"></div>
+  <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/register.js"></script>
+</body>
+</html>

--- a/china-motors-site/services.html
+++ b/china-motors-site/services.html
@@ -69,5 +69,6 @@
   <div id="siteFooter"></div>
 
   <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
 </body>
 </html>

--- a/china-motors-site/terms.html
+++ b/china-motors-site/terms.html
@@ -68,5 +68,6 @@
 <div id="siteFooter"></div>
 
 <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Frontend for the new backend registration endpoints:
- register.html: toggle between "Физ. лицо" and "Юр. лицо" forms, matching the two fields sets from v32fix_work (ФИО+ИИН vs Название компании+БИН+адрес)
- login.html: phone+password login
- js/auth.js: shared helper (register/login/logout, JWT stored in localStorage), used by both new pages
- js/register.js, js/login.js: form handlers for the two new pages
- partials/navbar.html + js/common.js (initAuthNav): the header now shows "Войти" or "Личный кабинет (не подтверждён)" depending on session state, with a logout confirm — added js/auth.js to every page that includes the shared navbar so this works site-wide
- common.js: added ru/kk/zh/en translations for all new labels

Broker/SVH/lab/logistics/declarant/bank/seller registration are follow-up stages, per the agreed plan.