### PR TITLE
Add personal account page — this is how deals actually get created/used

### DIFF
--- a/china-motors-site/account.html
+++ b/china-motors-site/account.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta name="api-base" content="https://cm-backend-daniyal.fly.dev">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Личный кабинет China Motors">
+
+  <meta name="theme-color" content="#0b2b5a">
+  <link rel="icon" href="/icons/icon-192.png">
+  <link rel="apple-touch-icon" href="/icons/icon-192.png">
+
+  <title data-i18n="title_account">China Motors - Личный кабинет</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Montserrat:wght@600&family=Oswald:wght@500&family=Open+Sans:wght@400;700&family=Poppins:wght@500;600&subset=cyrillic-ext&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+
+  <style>
+    .account-header {
+      max-width: 900px;
+      margin: 0 auto 20px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .account-badge {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 600;
+      margin-left: 8px;
+    }
+    .account-badge.verified { background: #1e7e34; color: #fff; }
+    .account-badge.not-verified { background: #a15c00; color: #fff; }
+
+    .deal-list { max-width: 900px; margin: 0 auto; display: flex; flex-direction: column; gap: 16px; }
+    .deal-card {
+      background: #1e1e1e;
+      border-radius: 12px;
+      padding: 20px;
+      text-align: left;
+    }
+    .deal-card h3 { color: #fff; margin-bottom: 6px; }
+    .deal-card .deal-meta { opacity: .8; font-size: 14px; margin-bottom: 12px; }
+
+    .assignment-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 0;
+      border-bottom: 1px dashed rgba(255,255,255,.1);
+      flex-wrap: wrap;
+    }
+    .assignment-row:last-child { border-bottom: none; }
+    .assignment-role { font-weight: 600; min-width: 140px; }
+    .assignment-status { font-size: 13px; opacity: .85; }
+    .assignment-status.PENDING { color: #cccccc; }
+    .assignment-status.IN_PROGRESS { color: #f0ad4e; }
+    .assignment-status.DONE { color: #4caf50; }
+
+    .my-assignment-form { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 8px; }
+    .my-assignment-form select, .my-assignment-form input {
+      padding: 8px;
+      border-radius: 6px;
+      border: 1px solid var(--primary-blue);
+      background: #1f1f1f;
+      color: #fff;
+    }
+
+    .comments-block { margin-top: 14px; border-top: 1px solid rgba(255,255,255,.1); padding-top: 12px; }
+    .comment-item { font-size: 14px; margin-bottom: 8px; opacity: .9; }
+    .comment-item b { opacity: .7; font-weight: 600; }
+    .comment-form { display: flex; gap: 8px; margin-top: 8px; }
+    .comment-form input { flex: 1; padding: 8px; border-radius: 6px; border: 1px solid var(--primary-blue); background: #1f1f1f; color: #fff; }
+
+    .empty-note { text-align: center; opacity: .7; padding: 30px 0; }
+  </style>
+</head>
+<body>
+  <div id="siteHeader"></div>
+
+  <section class="hero section fade-in">
+    <div class="container">
+      <div class="hero-overlay">
+        <h1 data-i18n="account_hero">Личный кабинет</h1>
+        <p class="White-p" id="accountRoleLine">—</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section fade-in">
+    <div class="container">
+      <div class="account-header">
+        <div></div>
+        <button class="btn" id="btnLogout"><i class="fas fa-right-from-bracket"></i> <span data-i18n="account_logout">Выйти</span></button>
+      </div>
+
+      <div id="dealList" class="deal-list">
+        <p class="empty-note" data-i18n="account_loading">Загрузка...</p>
+      </div>
+    </div>
+  </section>
+
+  <div id="siteFooter"></div>
+  <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/account.js"></script>
+</body>
+</html>

--- a/china-motors-site/js/account.js
+++ b/china-motors-site/js/account.js
@@ -1,0 +1,181 @@
+// js/account.js — личный кабинет: клиент видит свои сделки,
+// исполнитель (брокер/СВХ/лаборатория/логист/декларант/банк) видит
+// назначенные ему сделки и обновляет статус своего этапа.
+document.addEventListener('DOMContentLoaded', async () => {
+  const session = window.CMAuth?.getSession();
+  if (!session) {
+    location.href = 'login.html';
+    return;
+  }
+
+  const CUSTOMER_ROLES = ['CUSTOMER_PERSON', 'CUSTOMER_COMPANY'];
+  const ASSIGNEE_ROLES = ['SERVICE_BROKER', 'SERVICE_SVH', 'SERVICE_LAB', 'SERVICE_LOGISTIC', 'SERVICE_DECLARANT', 'BANK'];
+
+  const roleLine = document.getElementById('accountRoleLine');
+  const dealListEl = document.getElementById('dealList');
+  const roleLabels = {
+    CUSTOMER_PERSON: 'Клиент (физ. лицо)',
+    CUSTOMER_COMPANY: 'Клиент (юр. лицо)',
+    SERVICE_BROKER: 'Брокер (СВХ)',
+    SERVICE_SVH: 'СВХ',
+    SERVICE_LAB: 'Лаборатория',
+    SERVICE_LOGISTIC: 'Логист',
+    SERVICE_DECLARANT: 'Декларант (граница)',
+    BANK: 'Банк',
+    PARTNER: 'Партнёр-продавец',
+  };
+  const verifiedBadge = session.isVerified
+    ? '<span class="account-badge verified">подтверждён</span>'
+    : '<span class="account-badge not-verified">не подтверждён</span>';
+  roleLine.innerHTML = `${roleLabels[session.role] || session.role} ${verifiedBadge}`;
+
+  document.getElementById('btnLogout')?.addEventListener('click', () => {
+    window.CMAuth.logout();
+    location.href = 'index.html';
+  });
+
+  const STATUS_LABELS = { PENDING: 'Ожидает', IN_PROGRESS: 'В работе', DONE: 'Завершено' };
+  const ROLE_LABELS_SHORT = {
+    BROKER: 'Брокер (СВХ)', SVH: 'СВХ', LAB: 'Лаборатория',
+    LOGISTIC: 'Логист', DECLARANT: 'Декларант', BANK: 'Банк',
+  };
+
+  function fmtDate(iso) {
+    return new Date(iso).toLocaleString('ru-RU');
+  }
+
+  async function loadComments(dealId, container) {
+    try {
+      const comments = await window.CMAuth.apiAuthed('GET', `/api/deals/${dealId}/comments/`);
+      container.innerHTML = comments.length
+        ? comments.map(c => `<div class="comment-item"><b>${c.author_info?.name || c.author_info?.phone || '—'}:</b> ${escapeHtml(c.text)}</div>`).join('')
+        : '<div class="comment-item" style="opacity:.6">Пока нет сообщений</div>';
+    } catch (e) {
+      container.innerHTML = `<div class="comment-item" style="color:#e74c3c">Ошибка загрузки: ${e.message}</div>`;
+    }
+  }
+
+  function escapeHtml(s) {
+    const div = document.createElement('div');
+    div.textContent = s;
+    return div.innerHTML;
+  }
+
+  function buildCommentsBlock(dealId) {
+    const wrap = document.createElement('div');
+    wrap.className = 'comments-block';
+    wrap.innerHTML = `
+      <div class="comments-list"></div>
+      <form class="comment-form">
+        <input type="text" placeholder="Написать сообщение..." required>
+        <button type="submit" class="btn">Отправить</button>
+      </form>
+    `;
+    const list = wrap.querySelector('.comments-list');
+    loadComments(dealId, list);
+
+    wrap.querySelector('.comment-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const input = e.target.querySelector('input');
+      const text = input.value.trim();
+      if (!text) return;
+      try {
+        await window.CMAuth.apiAuthed('POST', `/api/deals/${dealId}/comments/`, { text });
+        input.value = '';
+        loadComments(dealId, list);
+      } catch (err) {
+        alert('Ошибка: ' + err.message);
+      }
+    });
+
+    return wrap;
+  }
+
+  function buildDealCard(deal, { editableRole } = {}) {
+    const card = document.createElement('div');
+    card.className = 'deal-card';
+
+    const assignmentsHtml = deal.assignments.length
+      ? deal.assignments.map(a => {
+          const isMine = editableRole && a.role === editableRole;
+          if (!isMine) {
+            return `
+              <div class="assignment-row">
+                <span class="assignment-role">${ROLE_LABELS_SHORT[a.role] || a.role}</span>
+                <span>${a.assigned_user_info?.name || a.assigned_user_info?.phone || '— не назначен'}</span>
+                <span class="assignment-status ${a.status}">${STATUS_LABELS[a.status] || a.status}</span>
+              </div>`;
+          }
+          return `
+            <div class="assignment-row">
+              <span class="assignment-role">${ROLE_LABELS_SHORT[a.role] || a.role} (вы)</span>
+              <form class="my-assignment-form" data-assignment-id="${a.id}">
+                <select name="status">
+                  ${Object.entries(STATUS_LABELS).map(([v, l]) => `<option value="${v}" ${v === a.status ? 'selected' : ''}>${l}</option>`).join('')}
+                </select>
+                <input type="text" name="note" placeholder="Заметка" value="${escapeHtml(a.note || '')}">
+                <button type="submit" class="btn">Сохранить</button>
+              </form>
+            </div>`;
+        }).join('')
+      : '<p style="opacity:.7">Пока никто не назначен</p>';
+
+    card.innerHTML = `
+      <h3>${deal.vehicle_title || deal.title || ('Сделка #' + deal.id)}</h3>
+      <div class="deal-meta">
+        Статус сделки: <b>${deal.status}</b> · Создана: ${fmtDate(deal.created_at)}
+        ${editableRole ? '' : `<br>Клиент: ${deal.customer_info?.name || deal.customer_info?.phone || '—'}`}
+      </div>
+      <div class="assignments-block">${assignmentsHtml}</div>
+    `;
+
+    card.querySelectorAll('.my-assignment-form').forEach(form => {
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const id = form.dataset.assignmentId;
+        const status = form.querySelector('[name="status"]').value;
+        const note = form.querySelector('[name="note"]').value;
+        try {
+          await window.CMAuth.apiAuthed('PATCH', `/api/deals/assignments/${id}/`, { status, note });
+          alert('Сохранено');
+        } catch (err) {
+          alert('Ошибка: ' + err.message);
+        }
+      });
+    });
+
+    card.appendChild(buildCommentsBlock(deal.id));
+    return card;
+  }
+
+  async function render() {
+    dealListEl.innerHTML = '<p class="empty-note">Загрузка...</p>';
+    try {
+      if (CUSTOMER_ROLES.includes(session.role)) {
+        const deals = await window.CMAuth.apiAuthed('GET', '/api/deals/my/');
+        dealListEl.innerHTML = '';
+        if (!deals.length) {
+          dealListEl.innerHTML = '<p class="empty-note">У вас пока нет сделок. Оформить сделку можно со страницы конкретной техники в каталоге — кнопка «Оформить сделку».</p>';
+          return;
+        }
+        deals.forEach(d => dealListEl.appendChild(buildDealCard(d)));
+      } else if (ASSIGNEE_ROLES.includes(session.role)) {
+        const deals = await window.CMAuth.apiAuthed('GET', '/api/deals/assigned/');
+        dealListEl.innerHTML = '';
+        if (!deals.length) {
+          dealListEl.innerHTML = '<p class="empty-note">Вам пока не назначили ни одной сделки.</p>';
+          return;
+        }
+        // роль в DealAssignment (BROKER/SVH/...) без префикса SERVICE_
+        const shortRole = session.role.startsWith('SERVICE_') ? session.role.replace('SERVICE_', '') : session.role;
+        deals.forEach(d => dealListEl.appendChild(buildDealCard(d, { editableRole: shortRole })));
+      } else {
+        dealListEl.innerHTML = '<p class="empty-note">Личный кабинет для этой роли пока в разработке.</p>';
+      }
+    } catch (e) {
+      dealListEl.innerHTML = `<p class="empty-note" style="color:#e74c3c">Ошибка загрузки: ${e.message}</p>`;
+    }
+  }
+
+  render();
+});

--- a/china-motors-site/js/auth.js
+++ b/china-motors-site/js/auth.js
@@ -9,11 +9,13 @@
   const LS_REFRESH = 'cm_refresh';
   const LS_ROLE = 'cm_role';
   const LS_VERIFIED = 'cm_verified';
+  const LS_USER_ID = 'cm_user_id';
 
-  function saveSession({ access, refresh, role, is_verified }) {
+  function saveSession({ access, refresh, role, is_verified, user_id }) {
     if (access) localStorage.setItem(LS_ACCESS, access);
     if (refresh) localStorage.setItem(LS_REFRESH, refresh);
     if (role) localStorage.setItem(LS_ROLE, role);
+    if (user_id) localStorage.setItem(LS_USER_ID, user_id);
     localStorage.setItem(LS_VERIFIED, is_verified ? '1' : '0');
   }
 
@@ -22,6 +24,7 @@
     localStorage.removeItem(LS_REFRESH);
     localStorage.removeItem(LS_ROLE);
     localStorage.removeItem(LS_VERIFIED);
+    localStorage.removeItem(LS_USER_ID);
   }
 
   function getSession() {
@@ -32,6 +35,7 @@
       refresh: localStorage.getItem(LS_REFRESH),
       role: localStorage.getItem(LS_ROLE),
       isVerified: localStorage.getItem(LS_VERIFIED) === '1',
+      userId: Number(localStorage.getItem(LS_USER_ID)) || null,
     };
   }
 
@@ -100,8 +104,62 @@
     clearSession();
   }
 
+  async function refreshAccess() {
+    const refresh = localStorage.getItem(LS_REFRESH);
+    if (!refresh) return null;
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/refresh/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh }),
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      localStorage.setItem(LS_ACCESS, data.access);
+      return data.access;
+    } catch {
+      return null;
+    }
+  }
+
+  // Авторизованный запрос — вешает Bearer-токен, при 401 один раз
+  // пробует обновить access через refresh-токен и повторяет запрос.
+  async function apiAuthed(method, path, body) {
+    let session = getSession();
+    if (!session) throw new Error('NOT_AUTHENTICATED');
+
+    async function doFetch(token) {
+      return fetch(`${API_BASE}${path}`, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    }
+
+    let res = await doFetch(session.access);
+    if (res.status === 401) {
+      const newAccess = await refreshAccess();
+      if (!newAccess) {
+        clearSession();
+        throw new Error('SESSION_EXPIRED');
+      }
+      res = await doFetch(newAccess);
+    }
+
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const firstError = Object.values(data)[0];
+      const message = Array.isArray(firstError) ? firstError[0] : (data.detail || 'Ошибка запроса');
+      throw new Error(message);
+    }
+    return data;
+  }
+
   window.CMAuth = {
     API_BASE, registerPerson, registerCompany, registerService, registerBank, registerPartner,
-    login, logout, getSession,
+    login, logout, getSession, apiAuthed,
   };
 })();

--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -58,6 +58,11 @@
       register_partner_note: 'Партнёр получает кабинет и загружает объявления техники — они проходят модерацию администратора.',
       register_country_label: 'Страна',
       register_regno_label: 'Регистрационный номер компании (для договора)',
+      title_account: 'China Motors - Личный кабинет',
+      account_hero: 'Личный кабинет',
+      account_logout: 'Выйти',
+      account_loading: 'Загрузка...',
+      product_create_deal: 'Оформить сделку',
 
       // COMMON
       brand_title: 'China Motors',
@@ -328,6 +333,11 @@
       register_partner_note: 'Серіктес кабинет алады және техника хабарландыруларын жүктейді — олар әкімші модерациясынан өтеді.',
       register_country_label: 'Ел',
       register_regno_label: 'Компанияның тіркеу нөмірі (келісімшарт үшін)',
+      title_account: 'China Motors - Жеке кабинет',
+      account_hero: 'Жеке кабинет',
+      account_logout: 'Шығу',
+      account_loading: 'Жүктелуде...',
+      product_create_deal: 'Мәміле рәсімдеу',
 
       brand_title: 'China Motors',
       hero_title_main: 'China Motors',
@@ -585,6 +595,11 @@
       register_partner_note: '合作伙伴将获得账户并上传车辆信息 — 需经管理员审核。',
       register_country_label: '国家',
       register_regno_label: '公司注册号（用于合同）',
+      title_account: 'China Motors - 个人中心',
+      account_hero: '个人中心',
+      account_logout: '退出',
+      account_loading: '加载中...',
+      product_create_deal: '办理交易',
 
       brand_title: 'China Motors',
       hero_title_main: 'China Motors',
@@ -842,6 +857,11 @@
       register_partner_note: 'Partners get a dashboard and upload vehicle listings — subject to admin moderation.',
       register_country_label: 'Country',
       register_regno_label: 'Company registration number (for the contract)',
+      title_account: 'China Motors - Account',
+      account_hero: 'Account',
+      account_logout: 'Log out',
+      account_loading: 'Loading...',
+      product_create_deal: 'Create a deal',
 
       brand_title: 'China Motors',
       hero_title_main: 'China Motors',
@@ -1146,18 +1166,12 @@
     const label = link.querySelector('span');
 
     if (session) {
-      link.href = '#';
+      link.href = 'account.html';
       if (label) label.setAttribute('data-i18n', 'nav_account');
       label.textContent = session.isVerified
         ? window.t('nav_account')
         : `${window.t('nav_account')} (${window.t('nav_not_verified')})`;
-      link.onclick = (e) => {
-        e.preventDefault();
-        if (confirm(window.t('nav_logout_confirm'))) {
-          window.CMAuth.logout();
-          location.reload();
-        }
-      };
+      link.onclick = null;
     } else {
       link.href = 'login.html';
       if (label) {

--- a/china-motors-site/js/login.js
+++ b/china-motors-site/js/login.js
@@ -25,7 +25,8 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       await window.CMAuth.login({ phone, password });
       showStatus(t('login_success'), false);
-      setTimeout(() => { location.href = 'index.html'; }, 1000);
+      const next = new URLSearchParams(location.search).get('next');
+      setTimeout(() => { location.href = next || 'index.html'; }, 1000);
     } catch (err) {
       showStatus(err.message, true);
       btn.disabled = false;

--- a/china-motors-site/js/product.js
+++ b/china-motors-site/js/product.js
@@ -23,8 +23,31 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const btnCalc = document.getElementById('btnCalc');
   const btnReq  = document.getElementById('btnRequest');
+  const btnCreateDeal = document.getElementById('btnCreateDeal');
   const extraEl = document.getElementById('extraInfo');
   const videoEl = document.getElementById('videoReview');
+
+  const CUSTOMER_ROLES = ['CUSTOMER_PERSON', 'CUSTOMER_COMPANY'];
+
+  btnCreateDeal?.addEventListener('click', async () => {
+    const session = window.CMAuth?.getSession();
+    if (!session) {
+      location.href = `login.html?next=${encodeURIComponent(location.href)}`;
+      return;
+    }
+    if (!CUSTOMER_ROLES.includes(session.role)) {
+      alert('Оформить сделку может только клиент (физ. или юр. лицо).');
+      return;
+    }
+    btnCreateDeal.disabled = true;
+    try {
+      await window.CMAuth.apiAuthed('POST', '/api/deals/my/', { vehicle_id: Number(id) });
+      location.href = 'account.html';
+    } catch (e) {
+      alert('Ошибка: ' + e.message);
+      btnCreateDeal.disabled = false;
+    }
+  });
 
   function buildTikTokEmbed(url) {
     if (!videoEl || !url) return;

--- a/china-motors-site/product.html
+++ b/china-motors-site/product.html
@@ -219,6 +219,9 @@
           <a id="btnCalc" class="btn btn--primary">
             <i class="fa fa-calculator"></i> Рассчитать стоимость
           </a>
+          <button id="btnCreateDeal" class="btn" type="button">
+            <i class="fa fa-file-signature"></i> <span data-i18n="product_create_deal">Оформить сделку</span>
+          </button>
         </div>
 
         <ul class="trust-list">


### PR DESCRIPTION
Answers "как создать deal" and "почему нет личного кабинета": the previous delivery was API-only (Deal/DealAssignment endpoints existed but nothing in the UI called them).

- account.html + js/account.js: role-aware personal cabinet — customers see their deals (vehicle, status, who's assigned, live comment thread); assigned service/bank accounts see deals assigned to them and can update their own stage's status + note inline
- product.html: added an "Оформить сделку" button next to "Рассчитать стоимость" — this is the actual entry point that calls POST /api/deals/my/ with the vehicle's id, so a deal now gets created from the page a customer is already on, not via curl
- js/auth.js: added apiAuthed() (Bearer token + one silent refresh retry on 401) so account.js can call the deal endpoints; user_id is now stored alongside role so the account page can tell which assignment row in a deal belongs to the logged-in assignee
- common.js/js/common.js: nav "Личный кабинет" link now goes to account.html (logout moved into the account page itself, instead of firing on the nav link click)
- js/login.js: supports ?next= so login redirects back to the page the customer was trying to act on (e.g. after clicking "Оформить сделку" while logged out)