### PR TITLE
Redesign product page to match new style; fix contact form 500 + vali…

### DIFF
--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -76,6 +76,11 @@
       account_listing_description_label: 'Описание',
       badge_user_listing_prefix: 'Объявление от',
       product_create_deal: 'Оформить сделку',
+      product_secure_note: 'Безопасная оплата через банк · полный пакет документов',
+      product_extra_title: 'Комплектация и характеристики',
+      product_cta_title: 'Хотите приобрести эту технику?',
+      product_cta_sub: 'Рассчитаем полную стоимость и оформим сделку по договору.',
+      product_cta_ask: 'Задать вопрос',
 
       // COMMON
       brand_title: 'China Motors',
@@ -409,6 +414,11 @@
       account_listing_description_label: 'Сипаттама',
       badge_user_listing_prefix: 'Хабарландыру:',
       product_create_deal: 'Мәміле рәсімдеу',
+      product_secure_note: 'Банк арқылы қауіпсіз төлем · құжаттардың толық жинағы',
+      product_extra_title: 'Жиынтықтама және сипаттамалар',
+      product_cta_title: 'Осы техниканы сатып алғыңыз келе ме?',
+      product_cta_sub: 'Толық құнын есептейміз және шарт бойынша мәміле рәсімдейміз.',
+      product_cta_ask: 'Сұрақ қою',
 
       brand_title: 'China Motors',
       hero_title_main: 'Қытайдан арнайы техника мен автомобильдер, кілт тапсыру форматында',
@@ -729,6 +739,11 @@
       account_listing_description_label: '描述',
       badge_user_listing_prefix: '来自',
       product_create_deal: '办理交易',
+      product_secure_note: '通过银行安全付款 · 提供完整证件',
+      product_extra_title: '配置与规格',
+      product_cta_title: '想购买这台设备吗?',
+      product_cta_sub: '我们将核算完整费用并按合同办理交易。',
+      product_cta_ask: '提出问题',
 
       brand_title: 'China Motors',
       hero_title_main: '来自中国的专用设备和汽车,一站式服务',
@@ -1049,6 +1064,11 @@
       account_listing_description_label: 'Description',
       badge_user_listing_prefix: 'Listed by',
       product_create_deal: 'Create a deal',
+      product_secure_note: 'Secure payment through the bank · full set of documents',
+      product_extra_title: 'Specifications and equipment',
+      product_cta_title: 'Want to buy this unit?',
+      product_cta_sub: "We'll calculate the full cost and arrange the deal under contract.",
+      product_cta_ask: 'Ask a question',
 
       brand_title: 'China Motors',
       hero_title_main: 'Special equipment and vehicles from China, turnkey',

--- a/china-motors-site/js/contacts.js
+++ b/china-motors-site/js/contacts.js
@@ -47,11 +47,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const phone = phoneEl?.value?.trim() || '';
     const msg = msgEl?.value?.trim() || '';
 
-    // simple validation
+    // simple validation — телефон разрешает +, цифры, пробелы, дефисы
+    // и скобки (плейсхолдер показывает формат "+7 (___) ___-__-__",
+    // так что скобки должны проходить, а не блокировать отправку).
     let valid = true;
     phoneEl?.style.removeProperty('border-color');
     msgEl?.style.removeProperty('border-color');
-    if (!phone || !/^\+?[0-9\s-]{6,}$/.test(phone)) {
+    if (!phone || !/^\+?[0-9()\s-]{6,}$/.test(phone)) {
       phoneEl?.style.setProperty('border-color', 'red');
       valid = false;
     }
@@ -78,6 +80,11 @@ document.addEventListener('DOMContentLoaded', () => {
         statusEl.className = 'success';
         statusEl.style.display = 'block';
       }
+      // Поля очищаем только при успехе — при ошибке пользователь не
+      // должен терять то, что уже написал, и может просто нажать ещё раз.
+      nameEl && (nameEl.value = '');
+      phoneEl && (phoneEl.value = '');
+      msgEl && (msgEl.value = '');
     } catch (err) {
       console.error(err);
       if (statusEl) {
@@ -86,10 +93,6 @@ document.addEventListener('DOMContentLoaded', () => {
         statusEl.style.display = 'block';
       }
     }
-
-    nameEl && (nameEl.value = '');
-    phoneEl && (phoneEl.value = '');
-    msgEl && (msgEl.value = '');
 
     sendBtn.disabled = false;
     sendBtn.textContent = prev;

--- a/china-motors-site/js/product.js
+++ b/china-motors-site/js/product.js
@@ -22,10 +22,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const thumbsEl = document.getElementById('thumbs');
 
   const btnCalc = document.getElementById('btnCalc');
+  const btnCalcBanner = document.getElementById('btnCalcBanner');
   const btnReq  = document.getElementById('btnRequest');
   const btnCreateDeal = document.getElementById('btnCreateDeal');
-  const extraEl = document.getElementById('extraInfo');
+  const extraCardEl = document.getElementById('extraInfo');
+  const extraEl = document.getElementById('extraInfoText');
   const videoEl = document.getElementById('videoReview');
+  const breadcrumbTitleEl = document.getElementById('breadcrumbTitle');
+  const productSubtitleEl = document.getElementById('productSubtitle');
+  const availabilityBadgeEl = document.getElementById('availabilityBadge');
+  const cityBadgeEl = document.getElementById('cityBadge');
 
   const CUSTOMER_ROLES = ['CUSTOMER_PERSON', 'CUSTOMER_COMPANY'];
 
@@ -260,28 +266,43 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       document.title = `${title} — China Motors`;
+      if (breadcrumbTitleEl) breadcrumbTitleEl.textContent = title;
+      if (productSubtitleEl) {
+        productSubtitleEl.textContent =
+          [v.model, v.year].filter(Boolean).join(' · ');
+      }
+
+      if (availabilityBadgeEl && AVAIL_LABELS[v.availability]) {
+        availabilityBadgeEl.textContent = AVAIL_LABELS[v.availability];
+        availabilityBadgeEl.style.display = '';
+      }
+      if (cityBadgeEl && v.city) {
+        cityBadgeEl.textContent = v.city;
+        cityBadgeEl.style.display = '';
+      }
 
       buildGallery(images);
       buildSpecsTable(v);
       buildTikTokEmbed(v.tiktok_url);
 
-      if (v.extra_info && extraEl) {
+      if (v.extra_info && extraEl && extraCardEl) {
         extraEl.textContent = v.extra_info;
-        extraEl.style.display = '';
+        extraCardEl.style.display = '';
       }
 
       // === buttons ===
-      if (btnCalc) {
-        btnCalc.href =
-          `calculator.html?` +
-          `title=${encodeURIComponent(title)}` +
-          `&price=${encodeURIComponent(priceUsdForCalc ?? '')}` +
-          `&price_cny=${encodeURIComponent(price.currency === 'cny' ? (price.amount ?? '') : '')}` +
-          `&body=${encodeURIComponent(bodyCanon)}` +
-          `&body_raw=${encodeURIComponent(bodyRaw || '')}` +
-          `&weight=${encodeURIComponent(v.weight_t ?? '')}` +
-          `&year=${encodeURIComponent(v.year ?? '')}`;
-      }
+      const calcHref =
+        `calculator.html?` +
+        `title=${encodeURIComponent(title)}` +
+        `&price=${encodeURIComponent(priceUsdForCalc ?? '')}` +
+        `&price_cny=${encodeURIComponent(price.currency === 'cny' ? (price.amount ?? '') : '')}` +
+        `&body=${encodeURIComponent(bodyCanon)}` +
+        `&body_raw=${encodeURIComponent(bodyRaw || '')}` +
+        `&weight=${encodeURIComponent(v.weight_t ?? '')}` +
+        `&year=${encodeURIComponent(v.year ?? '')}`;
+
+      if (btnCalc) btnCalc.href = calcHref;
+      if (btnCalcBanner) btnCalcBanner.href = calcHref;
 
       if (btnReq) {
         btnReq.href =

--- a/china-motors-site/product.html
+++ b/china-motors-site/product.html
@@ -20,7 +20,23 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 
   <style>
-    .product-page { padding: 40px 0 80px; }
+    .product-page { padding: 24px 0 80px; background: #f5f6f8; }
+
+    .hp-breadcrumb {
+      max-width: 1200px;
+      margin: 0 auto 20px;
+      padding: 0 20px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      color: #8a8f9c;
+      flex-wrap: wrap;
+    }
+    .hp-breadcrumb a { color: #8a8f9c; text-decoration: none; }
+    .hp-breadcrumb a:hover { color: #E12821; }
+    .hp-breadcrumb span.current { color: #12172a; font-weight: 600; }
+
     .product-grid {
       display: grid;
       grid-template-columns: 1.2fr 1fr;
@@ -30,30 +46,64 @@
       .product-grid { grid-template-columns: 1fr; }
     }
 
+    .product-gallery__frame {
+      position: relative;
+      border-radius: 16px;
+      overflow: hidden;
+      box-shadow: 0 4px 24px rgba(18,23,42,0.08);
+      background: #fff;
+    }
+
     .product-gallery img {
       max-width: 100%;
-      max-height: 520px;
-      object-fit: contain;
-      background: #111;
-      border-radius: 16px;
+      max-height: 420px;
+      width: 100%;
+      object-fit: cover;
+      background: #fff;
+      display: block;
       cursor: zoom-in;
     }
 
+    .product-badge-availability,
+    .product-badge-city {
+      position: absolute;
+      top: 16px;
+      font-size: 12px;
+      font-weight: 700;
+      padding: 6px 14px;
+      border-radius: 999px;
+      color: #fff;
+    }
+    .product-badge-availability { left: 16px; background: #16a34a; }
+    .product-badge-city { right: 16px; background: rgba(18,23,42,0.85); font-weight: 600; }
+
     .thumbs {
-      display: flex;
-      gap: 8px;
-      margin-top: 10px;
-      overflow-x: auto;
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 10px;
+      margin-top: 12px;
     }
     .thumbs img {
-      width: 90px;
-      height: 60px;
+      width: 100%;
+      height: 76px;
       object-fit: cover;
-      border-radius: 8px;
+      border-radius: 10px;
       cursor: pointer;
-      opacity: .75;
+      opacity: .8;
+      border: 2px solid transparent;
     }
-    .thumbs img.active { opacity: 1; outline: 2px solid #e11d48; }
+    .thumbs img.active { opacity: 1; border-color: #E12821; }
+
+    .product-trust-card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 20px 24px;
+      box-shadow: 0 4px 24px rgba(18,23,42,0.06);
+      margin-top: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
 
     /* LIGHTBOX */
     .pg-lightbox {
@@ -104,72 +154,92 @@
     .pg-lightbox__nav--prev { left: 18px; }
     .pg-lightbox__nav--next { right: 18px; }
 
+    /* INFO CARD */
+    .product-info-card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 32px;
+      box-shadow: 0 4px 24px rgba(18,23,42,0.06);
+    }
+
+    .product-subtitle {
+      font-size: 14px;
+      color: #8a8f9c;
+      margin-bottom: 18px;
+    }
+
     /* TRUST LIST */
     .trust-list {
       list-style: none;
-      margin: 22px 0 0;
+      margin: 0;
       padding: 0;
       display: flex;
       flex-direction: column;
-      gap: 10px;
+      gap: 12px;
     }
     .trust-list li {
       display: flex;
       align-items: center;
       gap: 10px;
-      padding: 12px 16px;
-      background: rgba(255,255,255,.04);
-      border: 1px solid rgba(255,255,255,.08);
-      border-radius: 12px;
-      font-size: 15px;
+      font-size: 13.5px;
+      font-weight: 500;
+      color: #12172a;
     }
     .trust-list li i {
-      color: #ff3b30;
+      color: #16a34a;
       font-size: 16px;
       flex-shrink: 0;
     }
 
     /* EXTRA INFO */
-    .product-extra {
+    .product-extra-card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 32px;
+      box-shadow: 0 4px 24px rgba(18,23,42,0.06);
       margin-top: 24px;
-      padding-top: 16px;
-      border-top: 1px solid rgba(255,255,255,.08);
+    }
+    .product-extra-card h2 {
+      font-family: 'Oswald', sans-serif;
+      font-weight: 700;
+      font-size: 22px;
+      margin: 0 0 16px;
+      color: #12172a;
+    }
+    .product-extra {
       white-space: pre-line;
       line-height: 1.6;
-      opacity: .9;
+      color: #4b5165;
     }
 
-    .product-title { font-size: 28px; font-weight: 700; margin-bottom: 10px; }
-    .product-price { font-size: 22px; font-weight: 700; margin: 16px 0; }
+    .product-title { font-family: 'Oswald', sans-serif; font-size: 28px; font-weight: 700; margin-bottom: 6px; color: #12172a; }
+    .product-price { font-family: 'Oswald', sans-serif; font-size: 30px; font-weight: 700; margin: 0 0 20px; color: #E12821; }
 
     table.specs {
       width: 100%;
-      border-collapse: separate;
-      border-spacing: 0 6px;
-      margin-top: 20px;
-    }
-    table.specs tr {
-      background: rgba(255,255,255,.04);
+      border-collapse: collapse;
+      margin-top: 4px;
     }
     table.specs td {
-      padding: 12px 16px;
-      border: none;
+      padding: 10px 0;
+      border-bottom: 1px solid #eef0f4;
+    }
+    table.specs tr:last-child td {
+      border-bottom: none;
     }
     table.specs td:first-child {
-      opacity: .7;
-      font-size: 13px;
-      width: 50%;
-      border-radius: 10px 0 0 10px;
+      color: #8a8f9c;
+      font-size: 13.5px;
     }
     table.specs td:last-child {
       text-align: right;
       font-weight: 600;
-      border-radius: 0 10px 10px 0;
+      color: #12172a;
     }
     table.specs td i {
       width: 16px;
       margin-right: 8px;
-      color: #ff3b30;
+      color: #E12821;
     }
 
     /* FULL-WIDTH VIDEO SECTION */
@@ -188,8 +258,59 @@
       gap: 12px;
       margin-top: 24px;
       flex-wrap: wrap;
+    }
+    .product-actions .btn,
+    .product-actions #btnCreateDeal {
+      flex: 1;
+      min-width: 180px;
+      text-align: center;
+      border-radius: 999px;
       justify-content: center;
     }
+
+    .product-cta-banner {
+      background: #12172a;
+      border-radius: 16px;
+      padding: 36px;
+      margin-top: 32px;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+    }
+    .product-cta-banner__title {
+      font-family: 'Oswald', sans-serif;
+      font-weight: 700;
+      font-size: 22px;
+      color: #fff;
+      margin-bottom: 6px;
+    }
+    .product-cta-banner__sub { font-size: 14px; color: rgba(255,255,255,0.6); }
+    .product-cta-banner .btn-outline-light {
+      border: 1.5px solid rgba(255,255,255,0.5);
+      color: #fff;
+      padding: 14px 28px;
+      border-radius: 999px;
+      font-weight: 600;
+      font-size: 14px;
+      text-decoration: none;
+    }
+
+    html.dark .product-gallery__frame,
+    html.dark .product-trust-card,
+    html.dark .product-info-card,
+    html.dark .product-extra-card {
+      background: #1e1e1e;
+    }
+    html.dark .product-title,
+    html.dark .product-extra-card h2,
+    html.dark table.specs td:last-child {
+      color: #f5f5f5;
+    }
+    html.dark .trust-list li { color: #f5f5f5; }
+    html.dark .product-extra { color: #cfd4dd; }
+    html.dark table.specs td { border-bottom-color: rgba(255,255,255,.08); }
   </style>
 </head>
 
@@ -197,19 +318,41 @@
 
 <div id="siteHeader"></div>
 
-<section class="product-page section fade-in">
+<div class="hp-breadcrumb">
+  <a href="index.html" data-i18n="nav_home">Главная</a>
+  <span>/</span>
+  <a href="catalog.html" data-i18n="nav_catalog">Каталог</a>
+  <span>/</span>
+  <span class="current" id="breadcrumbTitle">—</span>
+</div>
+
+<section class="product-page fade-in">
   <div class="container">
     <div class="product-grid">
 
       <!-- ЛЕВО: ГАЛЕРЕЯ -->
       <div class="product-gallery">
-        <img id="mainImage" src="" alt="">
+        <div class="product-gallery__frame">
+          <img id="mainImage" src="" alt="">
+          <span class="product-badge-availability" id="availabilityBadge" style="display:none"></span>
+          <span class="product-badge-city" id="cityBadge" style="display:none"></span>
+        </div>
         <div class="thumbs" id="thumbs"></div>
+
+        <div class="product-trust-card">
+          <ul class="trust-list">
+            <li><i class="fa-solid fa-file-signature"></i><span data-i18n="why_card1_y">Работа по договору</span></li>
+            <li><i class="fa-solid fa-camera"></i><span data-i18n="why_card2_y">Фото и видео с погрузки и доставки</span></li>
+            <li><i class="fa-solid fa-calculator"></i><span data-i18n="why_card3_y">Прозрачный расчёт без «вдруг доплатите»</span></li>
+            <li><i class="fa-solid fa-file-shield"></i><span data-i18n="why_card4_y">Помощь с таможней и регистрацией</span></li>
+          </ul>
+        </div>
       </div>
 
       <!-- ПРАВО: ИНФО -->
-      <div>
+      <div class="product-info-card">
         <h1 class="product-title" id="productTitle">—</h1>
+        <div class="product-subtitle" id="productSubtitle"></div>
         <span class="cm-badge cm-badge--user-listing" id="userListingBadge" style="position:static; display:none; margin-bottom:8px;"></span>
 
         <div class="product-price" id="productPrice">—</div>
@@ -224,20 +367,31 @@
             <i class="fa fa-file-signature"></i> <span data-i18n="product_create_deal">Оформить сделку</span>
           </button>
         </div>
-
-        <ul class="trust-list">
-          <li><i class="fa-solid fa-file-signature"></i><span data-i18n="why_card1_y">Работа по договору</span></li>
-          <li><i class="fa-solid fa-camera"></i><span data-i18n="why_card2_y">Фото и видео с погрузки и доставки</span></li>
-          <li><i class="fa-solid fa-calculator"></i><span data-i18n="why_card3_y">Прозрачный расчёт без «вдруг доплатите»</span></li>
-          <li><i class="fa-solid fa-file-shield"></i><span data-i18n="why_card4_y">Помощь с таможней и регистрацией</span></li>
-        </ul>
-
-        <div class="product-extra" id="extraInfo" style="display:none"></div>
+        <div style="display:flex;align-items:center;justify-content:center;gap:8px;margin-top:14px;font-size:12.5px;color:#8a8f9c">
+          <i class="fa-solid fa-shield-halved"></i>
+          <span data-i18n="product_secure_note">Безопасная оплата через банк · полный пакет документов</span>
+        </div>
       </div>
 
     </div>
 
+    <div class="product-extra-card" id="extraInfo" style="display:none">
+      <h2 data-i18n="product_extra_title">Комплектация и характеристики</h2>
+      <div class="product-extra" id="extraInfoText"></div>
+    </div>
+
     <div class="product-video-section" id="videoReview" style="display:none"></div>
+
+    <div class="product-cta-banner">
+      <div>
+        <div class="product-cta-banner__title" data-i18n="product_cta_title">Хотите приобрести эту технику?</div>
+        <div class="product-cta-banner__sub" data-i18n="product_cta_sub">Рассчитаем полную стоимость и оформим сделку по договору.</div>
+      </div>
+      <div style="display:flex;gap:12px;flex-wrap:wrap">
+        <a id="btnCalcBanner" class="btn btn--primary" data-i18n="hp_calc_submit">Рассчитать стоимость</a>
+        <a href="contacts.html" class="btn-outline-light" data-i18n="product_cta_ask">Задать вопрос</a>
+      </div>
+    </div>
   </div>
 </section>
 

--- a/china-motors-site/style.css
+++ b/china-motors-site/style.css
@@ -2195,7 +2195,7 @@ html.dark p {
   flex-wrap: wrap;
 }
 
-.hp-hero-cta .btn-outline-light {
+.btn-outline-light {
   border: 1.5px solid rgba(255,255,255,0.6);
   color: #fff;
   padding: 12px 26px;


### PR DESCRIPTION
…dation

- product.html: light card layout matching the rest of the redesign — breadcrumb, gallery card with availability/city badges, info card with subtitle line, spec rows, trust list, "Комплектация и характеристики" card (real extra_info text), bottom CTA banner. All real data wiring (gallery/lightbox, specs table, calculator/deal links, TikTok embed) is unchanged, just restyled
- Un-scope .btn-outline-light so it works outside the homepage hero too
- Fix contacts form 500: the CONTACT-<unix-seconds> fallback calc_id collided whenever two submissions landed in the same second, crashing on the CalculatorLead unique constraint; add a random suffix. Also broaden the product_id lookup to survive non-numeric input, and wrap Telegram delivery + the view body so failures return clean JSON instead of a raw 500
- contacts.js: allow parentheses in the phone validation regex (the placeholder shows "+7 (___) ___-__-__" but parens were rejected), and only clear the form fields on a successful submit so a failed request doesn't wipe out what the user typed