### PR TITLE
Add Избранное (favorites) page matching mockup

### DIFF
--- a/china-motors-site/favorites.html
+++ b/china-motors-site/favorites.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta name="api-base" content="https://cm-backend-daniyal.fly.dev">
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="Избранная техника China Motors — сравните и запросите расчёт">
+
+  <meta name="theme-color" content="#0b2b5a">
+
+  <link rel="icon" href="/icons/icon-192.png">
+
+  <link rel="apple-touch-icon" href="/icons/icon-192.png">
+
+  <meta name="apple-mobile-web-app-title" content="China Motors">
+
+  <meta property="og:title" content="China Motors">
+  <meta property="og:description" content="Спецтехника и авто из Китая">
+  <meta property="og:image" content="/path/to/preview.jpg">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://chinamotors.com.kz">
+  <title data-i18n="title_favorites">China Motors - Избранное</title>
+
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Montserrat:wght@600&family=Oswald:wght@500&family=Open+Sans:wght@400;700&family=Poppins:wght@500;600&subset=cyrillic-ext&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+</head>
+<body>
+  <div id="siteHeader"></div>
+
+  <section class="hp-page-head fade-in">
+    <div>
+      <h1 data-i18n="nav_favorites">Избранное</h1>
+      <p data-i18n="fav_subtitle">Сохранённая техника — сравните и запросите расчёт</p>
+    </div>
+    <div class="hp-page-head__count"><span data-i18n="fav_saved_count">Сохранено</span>: <span id="favCount">0</span></div>
+  </section>
+
+  <section class="section fade-in" style="padding-bottom:60px">
+    <div class="container">
+
+      <div id="favGrid" class="feature-grid"></div>
+
+      <div id="favCtaBanner" class="fav-cta-banner" style="display:none">
+        <div>
+          <div class="fav-cta-banner__title" data-i18n="fav_cta_title">Запросить расчёт по всему списку</div>
+          <div class="fav-cta-banner__sub" data-i18n="fav_cta_sub">Пришлём КП по каждой позиции из избранного — с доставкой до Алматы.</div>
+        </div>
+        <a id="favCtaBtn" href="contacts.html" class="fav-cta-banner__btn" data-i18n="fav_cta_btn">Получить КП по списку</a>
+      </div>
+
+      <div id="favEmpty" class="fav-empty" style="display:none">
+        <i class="fa-regular fa-bookmark"></i>
+        <div class="fav-empty__title" data-i18n="fav_empty_title">В избранном пока пусто</div>
+        <div class="fav-empty__sub" data-i18n="fav_empty_sub">Нажимайте на закладку на карточках техники в каталоге — они появятся здесь.</div>
+        <a href="catalog.html" class="fav-empty__btn" data-i18n="fav_empty_btn">Перейти в каталог</a>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <div id="siteFooter"></div>
+
+  <script src="js/common.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/favorites.js"></script>
+</body>
+</html>

--- a/china-motors-site/js/catalog.js
+++ b/china-motors-site/js/catalog.js
@@ -88,12 +88,16 @@ document.addEventListener('DOMContentLoaded', () => {
   /* ================= CARD ================= */
 
   function cardHTML(item) {
+    const isFav = window.CMFavorites?.isFavorite(item.id);
     return `
       <a class="cm-card" href="product.html?id=${item.id}">
         <div class="cm-card__image">
           <img src="${item.image}" alt="${item.title}">
           <span class="cm-badge cm-badge--${item.availability}">${AVAIL_LABELS[item.availability] || ''}</span>
           ${item.isUserListing ? `<span class="cm-badge cm-badge--user-listing">${window.t ? window.t('badge_user_listing_prefix') : 'Объявление от'} ${item.ownerRoleLabel || 'клиента'}</span>` : ''}
+          <button type="button" class="cm-card__fav-btn${isFav ? ' active' : ''}" data-fav-id="${item.id}" title="${window.t ? window.t('fav_remove_title') : 'Избранное'}">
+            <i class="fa-${isFav ? 'solid' : 'regular'} fa-bookmark"></i>
+          </button>
         </div>
 
         <div class="cm-card__body">
@@ -137,6 +141,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const countEl = document.getElementById('resultsCount');
     if (countEl) countEl.textContent = list.length;
   }
+
+  grid?.addEventListener('click', (e) => {
+    const btn = e.target.closest('.cm-card__fav-btn');
+    if (!btn) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const nowFav = window.CMFavorites?.toggleFavorite(btn.dataset.favId);
+    btn.classList.toggle('active', nowFav);
+    const icon = btn.querySelector('i');
+    if (icon) icon.className = `fa-${nowFav ? 'solid' : 'regular'} fa-bookmark`;
+  });
 
   /* ================= FILTER / SORT ================= */
 

--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -182,6 +182,19 @@
       catalog_hero: 'Актуальные предложения из базы',
       catalog_subhead: 'Каталог техники China Motors',
       catalog_found: 'Найдено',
+
+      // FAVORITES
+      title_favorites: 'China Motors - Избранное',
+      fav_subtitle: 'Сохранённая техника — сравните и запросите расчёт',
+      fav_saved_count: 'Сохранено',
+      fav_cta_title: 'Запросить расчёт по всему списку',
+      fav_cta_sub: 'Пришлём КП по каждой позиции из избранного — с доставкой до Алматы.',
+      fav_cta_btn: 'Получить КП по списку',
+      fav_empty_title: 'В избранном пока пусто',
+      fav_empty_sub: 'Нажимайте на закладку на карточках техники в каталоге — они появятся здесь.',
+      fav_empty_btn: 'Перейти в каталог',
+      fav_remove_title: 'Убрать из избранного',
+      fav_request_btn: 'Получить КП',
       filter_body_label: 'Тип транспорта',
       filter_source_label: 'Источник',
       filter_source_all: 'Все объявления',
@@ -527,6 +540,19 @@
       catalog_hero: 'Деректер базасындағы өзекті ұсыныстар',
       catalog_subhead: 'China Motors техника каталогы',
       catalog_found: 'Табылды',
+
+      // FAVORITES
+      title_favorites: 'China Motors - Таңдаулылар',
+      fav_subtitle: 'Сақталған техника — салыстырыңыз және есептеу сұраңыз',
+      fav_saved_count: 'Сақталды',
+      fav_cta_title: 'Барлық тізім бойынша есептеу сұрау',
+      fav_cta_sub: 'Таңдаулыдағы әр позиция бойынша КҰ жібереміз — Алматыға жеткізумен.',
+      fav_cta_btn: 'Тізім бойынша КҰ алу',
+      fav_empty_title: 'Таңдаулылар әзірге бос',
+      fav_empty_sub: 'Каталогтағы техника карточкаларындағы бетбелгіні басыңыз — олар осында пайда болады.',
+      fav_empty_btn: 'Каталогқа өту',
+      fav_remove_title: 'Таңдаулылардан алып тастау',
+      fav_request_btn: 'КҰ алу',
       filter_body_label: 'Көлік түрі',
       filter_source_label: 'Дереккөз',
       filter_source_all: 'Барлық хабарландырулар',
@@ -866,6 +892,19 @@
       catalog_hero: '数据库中的最新优惠',
       catalog_subhead: 'China Motors 设备目录',
       catalog_found: '找到',
+
+      // FAVORITES
+      title_favorites: 'China Motors - 收藏',
+      fav_subtitle: '已保存的设备 — 比较并申请报价',
+      fav_saved_count: '已保存',
+      fav_cta_title: '申请整个列表的报价',
+      fav_cta_sub: '我们将为收藏中的每一项发送报价单 — 含送达阿拉木图的运输。',
+      fav_cta_btn: '获取列表报价',
+      fav_empty_title: '收藏夹还是空的',
+      fav_empty_sub: '点击目录中设备卡片上的书签图标 — 它们将出现在这里。',
+      fav_empty_btn: '前往目录',
+      fav_remove_title: '从收藏中移除',
+      fav_request_btn: '获取报价',
       filter_body_label: '车型',
       filter_source_label: '来源',
       filter_source_all: '全部信息',
@@ -1206,6 +1245,19 @@
       catalog_hero: 'Latest offers from the database',
       catalog_subhead: 'China Motors equipment catalog',
       catalog_found: 'Found',
+
+      // FAVORITES
+      title_favorites: 'China Motors - Favorites',
+      fav_subtitle: 'Saved vehicles — compare and request a quote',
+      fav_saved_count: 'Saved',
+      fav_cta_title: 'Request a quote for the whole list',
+      fav_cta_sub: "We'll send a quote for every item in your favorites — delivered to Almaty.",
+      fav_cta_btn: 'Get a quote for the list',
+      fav_empty_title: 'No favorites yet',
+      fav_empty_sub: 'Tap the bookmark icon on any vehicle card in the catalog — it will appear here.',
+      fav_empty_btn: 'Go to catalog',
+      fav_remove_title: 'Remove from favorites',
+      fav_request_btn: 'Get a quote',
       filter_body_label: 'Vehicle type',
       filter_source_label: 'Source',
       filter_source_all: 'All listings',
@@ -1480,6 +1532,52 @@
     });
   }
 
+  /* =====================
+     FAVORITES (localStorage, per-device)
+     ===================== */
+  const LS_FAVORITES = 'cm_favorites';
+
+  function getFavorites() {
+    try {
+      const raw = JSON.parse(localStorage.getItem(LS_FAVORITES));
+      return Array.isArray(raw) ? raw.map(String) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function isFavorite(id) {
+    return getFavorites().includes(String(id));
+  }
+
+  function toggleFavorite(id) {
+    id = String(id);
+    const favs = getFavorites();
+    const idx = favs.indexOf(id);
+    if (idx === -1) favs.push(id);
+    else favs.splice(idx, 1);
+    localStorage.setItem(LS_FAVORITES, JSON.stringify(favs));
+    document.dispatchEvent(new CustomEvent('cm:favorites-changed', { detail: { favorites: favs } }));
+    return idx === -1;
+  }
+
+  window.CMFavorites = { getFavorites, isFavorite, toggleFavorite };
+
+  function initFavNav() {
+    const countEl = document.getElementById('navFavCount');
+    if (!countEl) return;
+    const render = () => {
+      const n = getFavorites().length;
+      countEl.textContent = n;
+      countEl.style.display = n > 0 ? '' : 'none';
+    };
+    render();
+    document.addEventListener('cm:favorites-changed', render);
+    window.addEventListener('storage', (e) => {
+      if (e.key === LS_FAVORITES) render();
+    });
+  }
+
   function initBurger() {
     const burger = document.querySelector('.menu-toggle');
     const navLinks = document.querySelector('.nav-links');
@@ -1547,6 +1645,7 @@
     initBurger();
     initAuthNav();
     initActiveNav();
+    initFavNav();
   });
 
 

--- a/china-motors-site/js/favorites.js
+++ b/china-motors-site/js/favorites.js
@@ -1,0 +1,136 @@
+// js/favorites.js — страница "Избранное": список сохранённых (localStorage)
+// ID техники, дотягиваем карточки с реального бэкенда по каждому ID.
+document.addEventListener('DOMContentLoaded', () => {
+
+  const metaBase = document.querySelector('meta[name="api-base"]')?.content;
+  const API_BASE = (metaBase || location.origin).replace(/\/+$/, '');
+
+  const gridEl = document.getElementById('favGrid');
+  const countEl = document.getElementById('favCount');
+  const ctaBanner = document.getElementById('favCtaBanner');
+  const ctaBtn = document.getElementById('favCtaBtn');
+  const emptyEl = document.getElementById('favEmpty');
+
+  const AVAIL_LABELS = {
+    in_stock: 'В наличии',
+    out_of_stock: 'Нет в наличии',
+    on_order: 'На заказ'
+  };
+
+  function fmtPrice(v) {
+    if (v.price_kzt) return `${Number(v.price_kzt).toLocaleString('ru-RU')} ₸`;
+    if (v.price_cny) return `${Number(v.price_cny).toLocaleString('ru-RU')} ¥`;
+    return 'Цена уточняется';
+  }
+
+  function cardHTML(v) {
+    const title = [v.brand, v.model, v.body_type].filter(Boolean).join(' ').trim() || `Техника #${v.id}`;
+    const img = v.image_url || (Array.isArray(v.images) && v.images[0]) || '/img/no-photo.png';
+    const availability = v.availability || 'in_stock';
+    return `
+      <div class="cm-card fav-card" data-vehicle-id="${v.id}">
+        <div class="cm-card__image">
+          <img src="${img}" alt="${title}">
+          <span class="cm-badge cm-badge--${availability}">${AVAIL_LABELS[availability] || ''}</span>
+          <button type="button" class="cm-card__fav-btn active" data-fav-id="${v.id}" title="${window.t ? window.t('fav_remove_title') : 'Убрать из избранного'}">
+            <i class="fa-solid fa-bookmark"></i>
+          </button>
+        </div>
+        <div class="cm-card__body">
+          <h3 class="cm-card__title">${title}${v.year ? `, ${v.year}` : ''}</h3>
+          <div class="cm-card__specs">
+            ${v.category || v.body_type ? `<div class="spec"><span data-i18n="card_body_label">Тип транспорта</span><strong>${v.category || v.body_type}</strong></div>` : ''}
+            ${v.wheel_formula ? `<div class="spec"><span data-i18n="card_wheel_formula_label">Колёсная формула</span><strong>${v.wheel_formula}</strong></div>` : ''}
+            ${v.gearbox ? `<div class="spec"><span data-i18n="card_gearbox_label">КПП</span><strong>${v.gearbox}</strong></div>` : ''}
+          </div>
+          <div class="fav-card__price">${fmtPrice(v)}</div>
+          <div class="fav-card__actions">
+            <a href="product.html?id=${v.id}" class="fav-card__btn fav-card__btn--dark" data-i18n="btn_calculate_catalog">Подробнее и расчёт</a>
+            <a href="contacts.html?product_id=${v.id}&message=${encodeURIComponent(`Запрос по технике:\n${title}\nЦена: ${fmtPrice(v)}`)}" class="fav-card__btn fav-card__btn--outline" data-i18n="fav_request_btn">Получить КП</a>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  function updateChrome(favIds, vehicles) {
+    if (countEl) countEl.textContent = favIds.length;
+
+    const hasItems = vehicles.length > 0;
+    if (gridEl) gridEl.style.display = hasItems ? '' : 'none';
+    if (ctaBanner) ctaBanner.style.display = hasItems ? '' : 'none';
+    if (emptyEl) emptyEl.style.display = favIds.length === 0 ? '' : 'none';
+
+    if (ctaBtn && hasItems) {
+      const list = vehicles
+        .map(v => `- ${[v.brand, v.model, v.body_type].filter(Boolean).join(' ').trim() || `Техника #${v.id}`}`)
+        .join('\n');
+      ctaBtn.href = `contacts.html?message=${encodeURIComponent(`Прошу расчёт по избранному списку техники:\n${list}`)}`;
+    }
+  }
+
+  function removeFavorite(id) {
+    window.CMFavorites?.toggleFavorite(id);
+    const card = gridEl?.querySelector(`.fav-card[data-vehicle-id="${id}"]`);
+    card?.remove();
+    render();
+  }
+
+  gridEl?.addEventListener('click', (e) => {
+    const btn = e.target.closest('.cm-card__fav-btn');
+    if (!btn) return;
+    e.preventDefault();
+    removeFavorite(btn.dataset.favId);
+  });
+
+  async function fetchVehicle(id) {
+    const r = await fetch(`${API_BASE}/api/vehicles/${id}/`);
+    if (r.status === 404) {
+      const err = new Error('Vehicle not found');
+      err.isNotFound = true;
+      throw err;
+    }
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    return r.json();
+  }
+
+  async function render() {
+    const favIds = window.CMFavorites?.getFavorites() || [];
+
+    if (favIds.length === 0) {
+      if (gridEl) gridEl.innerHTML = '';
+      updateChrome([], []);
+      return;
+    }
+
+    if (gridEl) gridEl.innerHTML = '<p class="empty-note">Загрузка…</p>';
+
+    const results = await Promise.allSettled(favIds.map(fetchVehicle));
+    const vehicles = [];
+    const stale = [];
+    let hadTransientError = false;
+
+    results.forEach((res, i) => {
+      if (res.status === 'fulfilled') vehicles.push(res.value);
+      else if (res.reason?.isNotFound) stale.push(favIds[i]);
+      else hadTransientError = true;
+    });
+
+    // Технику, которую удалили из каталога (подтверждённый 404), тихо
+    // убираем из избранного. Сетевые/серверные сбои — не трогаем список,
+    // просто не показываем эту позицию сейчас (иначе временная недоступность
+    // backend'а необратимо стёрла бы чьё-то избранное).
+    if (stale.length) {
+      const kept = favIds.filter(id => !stale.includes(id));
+      localStorage.setItem('cm_favorites', JSON.stringify(kept));
+      document.dispatchEvent(new CustomEvent('cm:favorites-changed', { detail: { favorites: kept } }));
+    }
+
+    const errorNote = hadTransientError
+      ? '<p class="empty-note" style="color:#e74c3c">Не удалось загрузить часть техники из избранного — попробуйте обновить страницу.</p>'
+      : '';
+    if (gridEl) gridEl.innerHTML = errorNote + vehicles.map(cardHTML).join('');
+    updateChrome(favIds.filter(id => !stale.includes(id)), vehicles);
+  }
+
+  render();
+});

--- a/china-motors-site/js/home.js
+++ b/china-motors-site/js/home.js
@@ -37,9 +37,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     const title = [v.brand, v.model, v.body_type].filter(Boolean).join(' ').trim() || `Техника #${v.id}`;
     const category = v.category || v.body_type || '';
     const img = v.image_url || (Array.isArray(v.images) && v.images[0]) || '/img/no-photo.png';
+    const isFav = window.CMFavorites?.isFavorite(v.id);
     return `
       <a class="hp-vehicle-card" href="product.html?id=${v.id}">
-        <img src="${img}" alt="${title}" loading="lazy">
+        <div class="hp-vehicle-card__image">
+          <img src="${img}" alt="${title}" loading="lazy">
+          <button type="button" class="cm-card__fav-btn${isFav ? ' active' : ''}" data-fav-id="${v.id}" title="${window.t ? window.t('fav_remove_title') : 'Избранное'}">
+            <i class="fa-${isFav ? 'solid' : 'regular'} fa-bookmark"></i>
+          </button>
+        </div>
         <div class="hp-vehicle-card__body">
           <div class="hp-vehicle-card__category">${category}</div>
           <div class="hp-vehicle-card__name">${title}</div>
@@ -50,6 +56,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   fillYearSelect();
+
+  grid?.addEventListener('click', (e) => {
+    const btn = e.target.closest('.cm-card__fav-btn');
+    if (!btn) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const nowFav = window.CMFavorites?.toggleFavorite(btn.dataset.favId);
+    btn.classList.toggle('active', nowFav);
+    const icon = btn.querySelector('i');
+    if (icon) icon.className = `fa-${nowFav ? 'solid' : 'regular'} fa-bookmark`;
+  });
 
   try {
     const res = await fetch(`${API_BASE}/api/vehicles/`);

--- a/china-motors-site/js/product.js
+++ b/china-motors-site/js/product.js
@@ -25,6 +25,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnCalcBanner = document.getElementById('btnCalcBanner');
   const btnReq  = document.getElementById('btnRequest');
   const btnCreateDeal = document.getElementById('btnCreateDeal');
+  const btnFav = document.getElementById('btnFav');
+
+  function syncFavBtn() {
+    if (!btnFav) return;
+    const isFav = window.CMFavorites?.isFavorite(id);
+    btnFav.classList.toggle('active', isFav);
+    const icon = btnFav.querySelector('i');
+    if (icon) icon.className = `fa-${isFav ? 'solid' : 'regular'} fa-bookmark`;
+  }
+  syncFavBtn();
+  btnFav?.addEventListener('click', () => {
+    window.CMFavorites?.toggleFavorite(id);
+    syncFavBtn();
+  });
   const extraCardEl = document.getElementById('extraInfo');
   const extraEl = document.getElementById('extraInfoText');
   const videoEl = document.getElementById('videoReview');

--- a/china-motors-site/partials/navbar.html
+++ b/china-motors-site/partials/navbar.html
@@ -48,9 +48,10 @@
         <span class="icon moon"><i class="fa-solid fa-moon"></i></span>
       </button>
 
-      <!-- Favorites (placeholder) -->
-      <a href="catalog.html" class="nav-icon-btn" title="Избранное" data-i18n-title="nav_favorites">
+      <!-- Favorites -->
+      <a href="favorites.html" class="nav-icon-btn" title="Избранное" data-i18n-title="nav_favorites">
         <i class="fa-regular fa-bookmark"></i>
+        <span class="nav-fav-count" id="navFavCount" style="display:none">0</span>
       </a>
 
       <!-- Burger -->

--- a/china-motors-site/product.html
+++ b/china-motors-site/product.html
@@ -351,7 +351,12 @@
 
       <!-- ПРАВО: ИНФО -->
       <div class="product-info-card">
-        <h1 class="product-title" id="productTitle">—</h1>
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;">
+          <h1 class="product-title" id="productTitle">—</h1>
+          <button type="button" id="btnFav" class="nav-icon-btn" data-i18n-title="fav_remove_title" title="Избранное" style="flex-shrink:0;">
+            <i class="fa-regular fa-bookmark"></i>
+          </button>
+        </div>
         <div class="product-subtitle" id="productSubtitle"></div>
         <span class="cm-badge cm-badge--user-listing" id="userListingBadge" style="position:static; display:none; margin-bottom:8px;"></span>
 

--- a/china-motors-site/style.css
+++ b/china-motors-site/style.css
@@ -1740,6 +1740,7 @@ html.dark .theme-toggle .moon {
 
 /* bookmark / favorites icon button */
 .nav-icon-btn {
+  position: relative;
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -1755,6 +1756,24 @@ html.dark .theme-toggle .moon {
   flex-shrink: 0;
 }
 .nav-icon-btn:hover { background: #f5f6f8; }
+.nav-icon-btn.active i { color: #E12821; }
+
+.nav-fav-count {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: #E12821;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 17px;
+  text-align: center;
+}
+html.dark .nav-fav-count { box-shadow: 0 0 0 2px #12172a; }
 
 /* ===============================
    LANGUAGE SWITCH (dropdown "шторка")
@@ -2170,6 +2189,28 @@ html.dark .cm-card {
   background: #2f6fed;
 }
 
+/* FAVORITE TOGGLE (bookmark) */
+.cm-card__fav-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.92);
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  transition: transform .15s ease;
+}
+.cm-card__fav-btn:hover { transform: scale(1.08); }
+.cm-card__fav-btn i { color: #8a8f9c; font-size: 14px; }
+.cm-card__fav-btn.active i { color: #E12821; }
+html.dark .cm-card__fav-btn { background: rgba(30,30,30,0.9); }
+
 /* BODY */
 .cm-card__body {
   padding: 18px 20px 20px;
@@ -2233,6 +2274,131 @@ html.dark .price {
 html.dark p {
   color: #e0e0e0;
 }
+
+/* =========================================================
+   FAVORITES PAGE
+   ========================================================= */
+.fav-card__price {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 20px;
+  margin: 10px 0 14px;
+}
+
+.fav-card__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fav-card__btn {
+  display: block;
+  text-align: center;
+  padding: 11px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13.5px;
+  text-decoration: none;
+}
+
+.fav-card__btn--dark {
+  background: #12172a;
+  color: #fff !important;
+}
+.fav-card__btn--dark:hover { background: #1c2440; color: #fff !important; }
+
+.fav-card__btn--outline {
+  border: 1px solid #e4e6eb;
+  color: #12172a !important;
+}
+.fav-card__btn--outline:hover { background: #f5f6f8; }
+
+html.dark .fav-card__btn--dark { background: #E12821; }
+html.dark .fav-card__btn--dark:hover { background: #c81e2c; }
+html.dark .fav-card__btn--outline { border-color: rgba(255,255,255,.15); color: #f5f5f5 !important; }
+html.dark .fav-card__btn--outline:hover { background: rgba(255,255,255,.06); }
+
+.fav-cta-banner {
+  background: #12172a;
+  border-radius: 16px;
+  padding: 32px;
+  margin-top: 36px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.fav-cta-banner__title {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 20px;
+  color: #fff;
+  margin-bottom: 6px;
+}
+
+.fav-cta-banner__sub {
+  font-size: 14px;
+  color: rgba(255,255,255,0.65);
+  max-width: 480px;
+}
+
+.fav-cta-banner__btn {
+  background: #E12821;
+  color: #fff !important;
+  padding: 14px 28px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+.fav-cta-banner__btn:hover { background: #c81e2c; }
+
+.fav-empty {
+  background: #fff;
+  border-radius: 16px;
+  padding: 72px 24px;
+  text-align: center;
+  box-shadow: 0 4px 24px rgba(18,23,42,0.06);
+}
+
+.fav-empty i {
+  font-size: 44px;
+  color: #d7dbe3;
+  margin-bottom: 18px;
+}
+
+.fav-empty__title {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 600;
+  font-size: 20px;
+  margin-bottom: 8px;
+}
+
+.fav-empty__sub {
+  font-size: 14px;
+  color: #6b7280;
+  margin-bottom: 24px;
+}
+
+.fav-empty__btn {
+  display: inline-block;
+  background: #E12821;
+  color: #fff !important;
+  padding: 14px 30px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 14.5px;
+  text-decoration: none;
+}
+.fav-empty__btn:hover { background: #c81e2c; }
+
+html.dark .fav-empty { background: #1e1e1e; box-shadow: none; }
+html.dark .fav-empty__title { color: #f5f5f5; }
+html.dark .fav-empty__sub { color: #aab4c5; }
+html.dark .fav-card__price { color: #f5f5f5; }
 
 /* =========================================================
    HOMEPAGE REDESIGN (hp-*) — hero, process, vehicle preview, stats
@@ -2570,6 +2736,8 @@ html.dark p {
   transform: translateY(-4px);
   box-shadow: 0 10px 28px rgba(18,23,42,0.15);
 }
+
+.hp-vehicle-card__image { position: relative; }
 
 .hp-vehicle-card img {
   width: 100%;


### PR DESCRIPTION
Bookmark toggle on catalog cards, homepage vehicle cards, and the product page saves vehicle IDs to localStorage (per-device, no login required). Navbar bookmark icon now links to a real favorites.html page with a live count badge instead of a placeholder link to the catalog. The favorites page fetches each saved vehicle by ID from the real API, renders cards matching the mockup (specs, price, availability badge, per-card CTA buttons), and a 'request quote for the whole list' banner that prefills the contact form.

Only a confirmed 404 (vehicle actually removed from the catalog) drops an item from favorites — a transient network/server error leaves the saved ID alone and just skips rendering it that pass, so a backend hiccup can't silently wipe someone's list.