### PR TITLE
Add Yandex.Metrika goal tracking for real conversions

### DIFF
--- a/china-motors-site/js/calculator.js
+++ b/china-motors-site/js/calculator.js
@@ -741,6 +741,8 @@
   document.getElementById('toContactsAside')?.addEventListener('click', (e) => {
     e.preventDefault();
 
+    window.cmGoal?.('calc_to_contacts_click');
+
     const msg = buildContactsMessage();
     const url = `/contacts.html?message=${encodeURIComponent(msg)}`;
     window.location.href = url;

--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -1563,6 +1563,31 @@
 
   window.CMFavorites = { getFavorites, isFavorite, toggleFavorite };
 
+  /* =====================
+     YANDEX.METRIKA GOALS
+     ===================== */
+  const YM_COUNTER_ID = 110843946;
+
+  function cmGoal(name, params) {
+    if (typeof window.ym === 'function') {
+      window.ym(YM_COUNTER_ID, 'reachGoal', name, params);
+    }
+  }
+  window.cmGoal = cmGoal;
+
+  // Клики по телефону/WhatsApp встречаются в футере, на контактах и т.д. —
+  // делегирование на document ловит их везде, включая шапку/футер, которые
+  // подгружаются отдельным fetch'ем позже.
+  function initGoalTracking() {
+    document.addEventListener('click', (e) => {
+      const a = e.target.closest('a[href]');
+      if (!a) return;
+      const href = a.getAttribute('href') || '';
+      if (href.startsWith('tel:')) cmGoal('phone_click');
+      else if (href.includes('wa.me')) cmGoal('whatsapp_click');
+    });
+  }
+
   function initFavNav() {
     const countEl = document.getElementById('navFavCount');
     if (!countEl) return;
@@ -1638,6 +1663,8 @@
      INIT
      ===================== */
   document.addEventListener('DOMContentLoaded', () => {
+
+    initGoalTracking();
 
     loadPartial('siteHeader', './partials/navbar.html', () => {
     initTheme();

--- a/china-motors-site/js/contacts.js
+++ b/china-motors-site/js/contacts.js
@@ -80,6 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
         statusEl.className = 'success';
         statusEl.style.display = 'block';
       }
+      window.cmGoal?.('contact_form_success');
       // Поля очищаем только при успехе — при ошибке пользователь не
       // должен терять то, что уже написал, и может просто нажать ещё раз.
       nameEl && (nameEl.value = '');

--- a/china-motors-site/js/product.js
+++ b/china-motors-site/js/product.js
@@ -62,6 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
     btnCreateDeal.disabled = true;
     try {
       await window.CMAuth.apiAuthed('POST', '/api/deals/my/', { vehicle_id: Number(id) });
+      window.cmGoal?.('deal_created');
       location.href = 'account.html';
     } catch (e) {
       alert('Ошибка: ' + e.message);

--- a/china-motors-site/js/register.js
+++ b/china-motors-site/js/register.js
@@ -45,6 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
       try {
         await action();
         showStatus(statusEl, t('register_success'), false);
+        window.cmGoal?.('registration_success');
         setTimeout(() => { location.href = 'index.html'; }, 1500);
       } catch (err) {
         showStatus(statusEl, err.message, true);


### PR DESCRIPTION
Traffic alone doesn't show whether visitors actually convert. Wired up reachGoal calls at the points that already represent a real lead or conversion:

- contact_form_success — contact form submitted successfully
- calc_to_contacts_click — calculator result sent to the contact form
- deal_created — 'Оформить сделку' succeeded on a product page
- registration_success — any of the 5 registration forms completed
- phone_click / whatsapp_click — tel:/wa.me links clicked anywhere on the site, via one delegated listener in common.js (catches footer and contacts-page links alike, including the ones loaded async)

Verified each fires exactly once at the right moment via a stubbed window.ym, including the two that navigate away immediately after (deal_created, calc_to_contacts_click) using page.exposeFunction to catch the call before the page tears down.