### PR TITLE
Optimize vehicle photos to WebP and add lazy-loading

### DIFF
--- a/china-motors-site/index.html
+++ b/china-motors-site/index.html
@@ -201,27 +201,27 @@
       <div class="gallery-grid">
         <!-- карточки галереи — как было -->
         <div class="card gallery-card">
-          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/v1756127944/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-06-19_%D0%B2_13.42.41_b73e1123_ss0yyn.jpg" class="gallery-img" alt="trailer">
+          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/f_auto,q_auto,w_600/v1756127944/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-06-19_%D0%B2_13.42.41_b73e1123_ss0yyn.jpg" class="gallery-img" loading="lazy" decoding="async" alt="trailer">
           <p data-i18n="gallery_cap1">Прицепы</p>
         </div>
         <div class="card gallery-card">
-          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/v1756127999/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.51.26_2b24706c_n8szas.jpg" class="gallery-img" alt="semi">
+          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/f_auto,q_auto,w_600/v1756127999/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.51.26_2b24706c_n8szas.jpg" class="gallery-img" loading="lazy" decoding="async" alt="semi">
           <p data-i18n="gallery_cap2">Полуприцепы</p>
         </div>
         <div class="card gallery-card">
-          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/v1756128059/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.43.12_99175c1b_voqpx6.jpg" class="gallery-img" alt="tral">
+          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/f_auto,q_auto,w_600/v1756128059/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.43.12_99175c1b_voqpx6.jpg" class="gallery-img" loading="lazy" decoding="async" alt="tral">
           <p data-i18n="gallery_cap3">Тралы</p>
         </div>
         <div class="card gallery-card">
-          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/v1756128154/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.33.43_8420c0d2_sgnoip.jpg" class="gallery-img" alt="dump">
+          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/f_auto,q_auto,w_600/v1756128154/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.33.43_8420c0d2_sgnoip.jpg" class="gallery-img" loading="lazy" decoding="async" alt="dump">
           <p data-i18n="gallery_cap4">Самосвалы</p>
         </div>
         <div class="card gallery-card">
-          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/v1756128035/%D0%98%D0%97%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.44.42_7445727d_drndzs.jpg" class="gallery-img" alt="truck">
+          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/f_auto,q_auto,w_600/v1756128035/%D0%98%D0%97%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.44.42_7445727d_drndzs.jpg" class="gallery-img" loading="lazy" decoding="async" alt="truck">
           <p data-i18n="gallery_cap5">Тягачи</p>
         </div>
         <div class="card gallery-card">
-          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/v1756128032/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.44.46_30e2e092_sxxiuc.jpg" class="gallery-img" alt="spec">
+          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/f_auto,q_auto,w_600/v1756128032/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-27_%D0%B2_18.44.46_30e2e092_sxxiuc.jpg" class="gallery-img" loading="lazy" decoding="async" alt="spec">
           <p data-i18n="gallery_cap6">Спецтехника</p>
         </div>
       </div>
@@ -279,16 +279,16 @@
         </div>
         <!-- Image Review Card -->
         <div class="review-card">
-          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/v1756127980/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-28_%D0%B2_17.16.01_d2a1c43b_jjja5b.jpg" loading="lazy" decoding="async" alt="Счастливый клиент с машиной" class="review-img">
+          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/f_auto,q_auto,w_600/v1756127980/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-28_%D0%B2_17.16.01_d2a1c43b_jjja5b.jpg" loading="lazy" decoding="async" alt="Счастливый клиент с машиной" class="review-img">
           <p  data-i18n="reviews_title2" class="review-caption">Клиент с новым автомобилем</p>
         </div>
         <!-- Another Image Review Card -->
         <div class="review-card">
-          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/v1756127981/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-28_%D0%B2_17.13.35_e5e328c3_kwvrrx.jpg" loading="lazy" decoding="async" alt="Техника на складе" class="review-img">
+          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/f_auto,q_auto,w_600/v1756127981/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-28_%D0%B2_17.13.35_e5e328c3_kwvrrx.jpg" loading="lazy" decoding="async" alt="Техника на складе" class="review-img">
           <p data-i18n="reviews_title1" class="review-caption">Техника у клиента</p>
         </div>
         <div class="review-card">
-          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/v1756127983/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-28_%D0%B2_17.13.32_e22d1fe3_xhpt6a.jpg" loading="lazy" decoding="async" alt="Техника на складе" class="review-img">
+          <img src="https://res.cloudinary.com/dkita2qyq/image/upload/f_auto,q_auto,w_600/v1756127983/%D0%98%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5_WhatsApp_2025-05-28_%D0%B2_17.13.32_e22d1fe3_xhpt6a.jpg" loading="lazy" decoding="async" alt="Техника на складе" class="review-img">
           <p data-i18n="reviews_title1" class="review-caption">Техника у клиента</p>
         </div>
       </div>

--- a/china-motors-site/js/catalog.js
+++ b/china-motors-site/js/catalog.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
       bodyRaw,
       brand: v.brand || '',
       wheelFormula: normText(v.wheel_formula || '') || extractWheelFormula(`${title} ${bodyRaw}`),
-      image: v.image_url || '/img/no-photo.png',
+      image: v.image_url ? (window.cmOptimizeImage?.(v.image_url, { width: 400 }) || v.image_url) : '/img/no-photo.png',
       availability: v.availability || 'in_stock',
       isUserListing: Boolean(v.is_user_listing),
       ownerRoleLabel: v.owner_role_label || '',
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return `
       <a class="cm-card" href="product.html?id=${item.id}">
         <div class="cm-card__image">
-          <img src="${item.image}" alt="${item.title}">
+          <img src="${item.image}" alt="${item.title}" loading="lazy" decoding="async">
           <span class="cm-badge cm-badge--${item.availability}">${AVAIL_LABELS[item.availability] || ''}</span>
           ${item.isUserListing ? `<span class="cm-badge cm-badge--user-listing">${window.t ? window.t('badge_user_listing_prefix') : 'Объявление от'} ${item.ownerRoleLabel || 'клиента'}</span>` : ''}
           <button type="button" class="cm-card__fav-btn${isFav ? ' active' : ''}" data-fav-id="${item.id}" title="${window.t ? window.t('fav_remove_title') : 'Избранное'}">

--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -1588,6 +1588,22 @@
     });
   }
 
+  /* =====================
+     IMAGE OPTIMIZATION (Cloudinary)
+     ===================== */
+  // Фото техники хранятся в Cloudinary — просим отдать WebP (там, где браузер
+  // его поддерживает) и ужатое под нужную ширину, вместо оригинала как есть.
+  // На остальные картинки (плейсхолдер /img/no-photo.png, внешние ссылки) не влияет.
+  function cmOptimizeImage(url, opts) {
+    if (!url || typeof url !== 'string') return url;
+    if (!url.includes('res.cloudinary.com') || !url.includes('/upload/')) return url;
+    if (/\/upload\/[^/]*f_auto/.test(url)) return url;
+    const width = opts && opts.width;
+    const transform = width ? `f_auto,q_auto,w_${width}` : 'f_auto,q_auto';
+    return url.replace('/upload/', `/upload/${transform}/`);
+  }
+  window.cmOptimizeImage = cmOptimizeImage;
+
   function initFavNav() {
     const countEl = document.getElementById('navFavCount');
     if (!countEl) return;

--- a/china-motors-site/js/favorites.js
+++ b/china-motors-site/js/favorites.js
@@ -25,12 +25,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function cardHTML(v) {
     const title = [v.brand, v.model, v.body_type].filter(Boolean).join(' ').trim() || `Техника #${v.id}`;
-    const img = v.image_url || (Array.isArray(v.images) && v.images[0]) || '/img/no-photo.png';
+    const rawImg = v.image_url || (Array.isArray(v.images) && v.images[0]) || '/img/no-photo.png';
+    const img = rawImg === '/img/no-photo.png' ? rawImg : (window.cmOptimizeImage?.(rawImg, { width: 400 }) || rawImg);
     const availability = v.availability || 'in_stock';
     return `
       <div class="cm-card fav-card" data-vehicle-id="${v.id}">
         <div class="cm-card__image">
-          <img src="${img}" alt="${title}">
+          <img src="${img}" alt="${title}" loading="lazy" decoding="async">
           <span class="cm-badge cm-badge--${availability}">${AVAIL_LABELS[availability] || ''}</span>
           <button type="button" class="cm-card__fav-btn active" data-fav-id="${v.id}" title="${window.t ? window.t('fav_remove_title') : 'Убрать из избранного'}">
             <i class="fa-solid fa-bookmark"></i>

--- a/china-motors-site/js/home.js
+++ b/china-motors-site/js/home.js
@@ -36,12 +36,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   function vehicleCard(v) {
     const title = [v.brand, v.model, v.body_type].filter(Boolean).join(' ').trim() || `Техника #${v.id}`;
     const category = v.category || v.body_type || '';
-    const img = v.image_url || (Array.isArray(v.images) && v.images[0]) || '/img/no-photo.png';
+    const rawImg = v.image_url || (Array.isArray(v.images) && v.images[0]) || '/img/no-photo.png';
+    const img = rawImg === '/img/no-photo.png' ? rawImg : (window.cmOptimizeImage?.(rawImg, { width: 300 }) || rawImg);
     const isFav = window.CMFavorites?.isFavorite(v.id);
     return `
       <a class="hp-vehicle-card" href="product.html?id=${v.id}">
         <div class="hp-vehicle-card__image">
-          <img src="${img}" alt="${title}" loading="lazy">
+          <img src="${img}" alt="${title}" loading="lazy" decoding="async">
           <button type="button" class="cm-card__fav-btn${isFav ? ' active' : ''}" data-fav-id="${v.id}" title="${window.t ? window.t('fav_remove_title') : 'Избранное'}">
             <i class="fa-${isFav ? 'solid' : 'regular'} fa-bookmark"></i>
           </button>

--- a/china-motors-site/js/product.js
+++ b/china-motors-site/js/product.js
@@ -278,11 +278,16 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
 
+  function optimize(src, width) {
+    return window.cmOptimizeImage?.(src, { width }) || src;
+  }
+
   function buildGallery(images) {
     if (!images.length) return;
-    galleryImages = images;
+    // Полное разрешение — для лайтбокса (там смотрят детали крупно).
+    galleryImages = images.map(src => optimize(src, 1200));
 
-    mainImg.src = images[0];
+    mainImg.src = optimize(images[0], 800);
     mainImg.alt = titleEl.textContent;
     mainImg.addEventListener('click', () => {
       const activeIdx = Math.max(0, [...thumbsEl.querySelectorAll('img')].findIndex(t => t.classList.contains('active')));
@@ -292,10 +297,12 @@ document.addEventListener('DOMContentLoaded', () => {
     thumbsEl.innerHTML = '';
     images.forEach((src, i) => {
       const img = document.createElement('img');
-      img.src = src;
+      img.src = optimize(src, 150);
+      img.loading = 'lazy';
+      img.decoding = 'async';
       if (i === 0) img.classList.add('active');
       img.addEventListener('click', () => {
-        mainImg.src = src;
+        mainImg.src = optimize(src, 800);
         thumbsEl.querySelectorAll('img').forEach(t => t.classList.remove('active'));
         img.classList.add('active');
       });


### PR DESCRIPTION
All vehicle photos are hosted on Cloudinary, so instead of trying to re-encode a growing, staff/client-uploaded catalog by hand, a shared cmOptimizeImage() helper in common.js rewrites Cloudinary URLs with f_auto,q_auto (serves WebP/AVIF to browsers that support it, at an automatically-tuned quality) plus a w_<size> sized to where each image actually renders — catalog/homepage/favorites cards, product gallery thumbnails and main image, product lightbox (kept larger there since people zoom in on purpose).

loading="lazy" + decoding="async" added everywhere except the product page's main hero image, which stays eager since it's the largest visible element on load (LCP) and delaying it would hurt rather than help.

Also applied the same Cloudinary transform + lazy-loading to the homepage's static Gallery images, which were still serving full- resolution originals with no loading attribute at all.