### PR TITLE
Fix sitewide horizontal overflow on mobile

### DIFF
--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -1637,6 +1637,46 @@
     });
   }
 
+  // На мобильных .nav-right (шторка языка + переключатель темы + избранное +
+  // бургер) физически не помещается в 375px рядом с логотипом — сдвигаем
+  // переключатели языка/темы в выпадающее меню, а не просто прячем их.
+  // Переносим сами узлы (не клоны), чтобы id/обработчики остались рабочими;
+  // якорь-комментарий помнит, куда вернуть их обратно на десктопе.
+  function initMobileNavControls() {
+    const navLinks = document.querySelector('.nav-links');
+    const langSwitch = document.getElementById('langSwitch');
+    const themeToggle = document.getElementById('themeToggle');
+    if (!navLinks || !langSwitch || !themeToggle) return;
+
+    const langAnchor = document.createComment('lang-switch-anchor');
+    const themeAnchor = document.createComment('theme-toggle-anchor');
+    langSwitch.before(langAnchor);
+    themeToggle.before(themeAnchor);
+
+    const langLi = document.createElement('li');
+    langLi.className = 'nav-mobile-extra';
+    langLi.appendChild(langSwitch);
+
+    const themeLi = document.createElement('li');
+    themeLi.className = 'nav-mobile-extra';
+    themeLi.appendChild(themeToggle);
+
+    const mq = window.matchMedia('(max-width: 768px)');
+    function apply(isMobile) {
+      if (isMobile) {
+        // Тема — сначала, шторка языка — последней: её выпадающее меню
+        // раскрывается вниз и иначе перекрывало бы кнопку темы под ней.
+        navLinks.appendChild(themeLi);
+        navLinks.appendChild(langLi);
+      } else {
+        langAnchor.after(langSwitch);
+        themeAnchor.after(themeToggle);
+      }
+    }
+    apply(mq.matches);
+    mq.addEventListener('change', (e) => apply(e.matches));
+  }
+
   // Показывает «Войти» или «Личный кабинет» в шапке — зависит от того,
   // залогинен ли клиент (js/auth.js, если подключён на странице).
   function initAuthNav() {
@@ -1689,6 +1729,7 @@
     initAuthNav();
     initActiveNav();
     initFavNav();
+    initMobileNavControls();
   });
 
 

--- a/china-motors-site/style.css
+++ b/china-motors-site/style.css
@@ -11,10 +11,12 @@ body {
   color: #000;
   background-color: #f9f9f9;
   font-size: 16px;
+  overflow-x: hidden;
 }
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 /* Dark theme */
@@ -1655,6 +1657,41 @@ html.dark .privacy-container a {
 
   .nav-links.active {
     right: 0;
+  }
+
+  /* .nav-links stops being a flex item once it's position:fixed, so the
+     overflow on small screens actually comes from .nav-left + the huge
+     desktop gap + .nav-right's 5 non-shrinking controls. #langSwitch and
+     #themeToggle get moved into this drawer by JS at this same breakpoint
+     (see initMobileNavControls in common.js) so nav-right only has to fit
+     the auth pill + favorites icon + burger. */
+  .container-navbar {
+    gap: 12px;
+    justify-content: space-between;
+  }
+  .nav-right {
+    gap: 8px;
+  }
+  .nav-auth-link {
+    padding: 9px 14px;
+    font-size: 12.5px;
+    max-width: 130px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .nav-mobile-extra {
+    width: 100%;
+    display: flex;
+  }
+  .nav-mobile-extra .lang-switch {
+    width: 100%;
+  }
+  .nav-mobile-extra .lang-toggle,
+  .nav-mobile-extra #themeToggle {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 10px;
   }
 }
 .nav-logo {


### PR DESCRIPTION
Every page had horizontal scroll on phone-width viewports (confirmed via Playwright at 375px on all 8 main pages). Two compounding causes:

1. .container-navbar had a flat 100px gap with no mobile override, and .nav-right (auth pill, language switch, theme toggle, favorites icon, burger) never shrank -- five non-collapsing controls plus the logo simply don't fit in 375px.
2. html/body had no overflow-x: hidden, so even once things stopped fitting, the closed mobile drawer (position:fixed; right:-100%) kept contributing to document.scrollWidth on its own, forcing a horizontal scrollbar site-wide regardless of viewport size.

Fix: language switch and theme toggle now move into the mobile drawer itself (via matchMedia, moving the actual DOM nodes so their existing ids/listeners keep working -- not clones) instead of trying to cram them into the top bar, leaving nav-right with just the auth pill + favorites icon + burger on small screens. Added overflow-x: hidden as a standard defensive baseline. Verified scrollWidth == clientWidth on all 8 pages afterward, and that desktop layout, dark-mode toggling, and the language dropdown all still work correctly (including from inside the mobile drawer).