### PR TITLE
Fix burger button hidden off-screen on mobile

### DIFF
--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -1646,12 +1646,21 @@
     const navLinks = document.querySelector('.nav-links');
     const langSwitch = document.getElementById('langSwitch');
     const themeToggle = document.getElementById('themeToggle');
+    const favBtn = document.querySelector('.nav-right .nav-icon-btn');
     if (!navLinks || !langSwitch || !themeToggle) return;
 
+    const favAnchor = favBtn ? document.createComment('fav-btn-anchor') : null;
+    if (favBtn) favBtn.before(favAnchor);
     const langAnchor = document.createComment('lang-switch-anchor');
     const themeAnchor = document.createComment('theme-toggle-anchor');
     langSwitch.before(langAnchor);
     themeToggle.before(themeAnchor);
+
+    const favLi = favBtn ? document.createElement('li') : null;
+    if (favLi) {
+      favLi.className = 'nav-mobile-extra';
+      favLi.appendChild(favBtn);
+    }
 
     const langLi = document.createElement('li');
     langLi.className = 'nav-mobile-extra';
@@ -1664,13 +1673,16 @@
     const mq = window.matchMedia('(max-width: 768px)');
     function apply(isMobile) {
       if (isMobile) {
-        // Тема — сначала, шторка языка — последней: её выпадающее меню
-        // раскрывается вниз и иначе перекрывало бы кнопку темы под ней.
+        // Тема — сначала, избранное — затем, шторка языка — последней: её
+        // выпадающее меню раскрывается вниз и иначе перекрывало бы то, что
+        // идёт следом.
         navLinks.appendChild(themeLi);
+        if (favLi) navLinks.appendChild(favLi);
         navLinks.appendChild(langLi);
       } else {
         langAnchor.after(langSwitch);
         themeAnchor.after(themeToggle);
+        if (favBtn) favAnchor.after(favBtn);
       }
     }
     apply(mq.matches);

--- a/china-motors-site/style.css
+++ b/china-motors-site/style.css
@@ -1661,24 +1661,35 @@ html.dark .privacy-container a {
 
   /* .nav-links stops being a flex item once it's position:fixed, so the
      overflow on small screens actually comes from .nav-left + the huge
-     desktop gap + .nav-right's 5 non-shrinking controls. #langSwitch and
-     #themeToggle get moved into this drawer by JS at this same breakpoint
-     (see initMobileNavControls in common.js) so nav-right only has to fit
-     the auth pill + favorites icon + burger. */
+     desktop gap + .nav-right's 5 non-shrinking controls. #langSwitch,
+     #themeToggle and the favorites icon get moved into this drawer by JS
+     at this same breakpoint (see initMobileNavControls in common.js) so
+     nav-right only has to fit the auth pill + burger. */
   .container-navbar {
-    gap: 12px;
+    gap: 8px;
     justify-content: space-between;
   }
   .nav-right {
-    gap: 8px;
+    gap: 6px;
   }
   .nav-auth-link {
-    padding: 9px 14px;
-    font-size: 12.5px;
-    max-width: 130px;
+    padding: 9px 12px;
+    font-size: 12px;
+    max-width: 110px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  .navbar .menu-toggle {
+    padding: 10px;
+    font-size: 22px;
+  }
+  /* "СПЕЦТЕХНИКА ИЗ КИТАЯ" at 2px letter-spacing is wider than the "China
+     Motors" title above it and was the single biggest driver of navbar
+     overflow -- tighten it down instead of hiding it outright. */
+  .logo-sub {
+    font-size: 8px;
+    letter-spacing: 0.5px;
   }
   .nav-mobile-extra {
     width: 100%;


### PR DESCRIPTION
The previous mobile-overflow fix added overflow-x:hidden, which stopped the horizontal scrollbar but silently clipped the burger button instead -- it was still positioned mostly past the 375px viewport edge (measured x:367, width:53, viewport 375), just no longer reachable by scrolling to it. That fix treated the symptom (scrollbar) without actually making .nav-left + .nav-right fit.

Measured why: the logo subtitle 'СПЕЦТЕХНИКА ИЗ КИТАЯ' at 2px letter-spacing rendered 167px wide -- wider than the 'China Motors' title above it -- making .nav-left 215px alone. Tightened it to 0.5px letter-spacing/8px font on mobile. Also moved the favorites icon button into the mobile drawer alongside language/theme (same DOM-relocation technique already used for those two), so nav-right only has to fit the auth pill + burger on small screens.

Verified via actual bounding-box measurements (not just visual screenshots) that the burger now sits fully inside the viewport with room to spare, all 3 relocated drawer controls render at distinct, non-overlapping positions, and desktop layout is unaffected.