### PR TITLE
Rebuild mobile nav as dedicated drawer per SiteHeader mockup

### DIFF
--- a/china-motors-site/js/common.js
+++ b/china-motors-site/js/common.js
@@ -1524,7 +1524,7 @@
      ACTIVE NAV LINK
      ===================== */
   function initActiveNav() {
-    const links = document.querySelectorAll('.nav-links a');
+    const links = document.querySelectorAll('.nav-links a, .nav-drawer__nav a');
     const current = location.pathname.split('/').pop() || 'index.html';
     links.forEach(a => {
       const hrefPage = (a.getAttribute('href') || '').split('#')[0].split('/').pop();
@@ -1619,70 +1619,68 @@
     });
   }
 
-  function initBurger() {
-    const burger = document.querySelector('.menu-toggle');
-    const navLinks = document.querySelector('.nav-links');
+  // Мобильная шторка (см. мокап SiteHeader) — отдельный <aside>, а не
+  // переиспользованный .nav-links. Открывается бургером, закрывается
+  // крестиком/оверлеем/Escape/кликом по ссылке.
+  function initMobileDrawer() {
+    const burger = document.getElementById('navBurger');
+    const drawer = document.getElementById('navDrawer');
+    const overlay = document.getElementById('navDrawerOverlay');
+    const closeBtn = document.getElementById('navDrawerClose');
+    const nav = document.getElementById('navDrawerNav');
+    if (!burger || !drawer || !overlay) return;
 
-    if (!burger || !navLinks) return;
+    function open() {
+      drawer.classList.add('active');
+      overlay.classList.add('active');
+    }
+    function close() {
+      drawer.classList.remove('active');
+      overlay.classList.remove('active');
+    }
 
-    burger.addEventListener('click', () => {
-      navLinks.classList.toggle('active');
+    burger.addEventListener('click', open);
+    closeBtn?.addEventListener('click', close);
+    overlay.addEventListener('click', close);
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') close();
     });
-
-    // закрытие меню при клике на пункт
-    navLinks.querySelectorAll('a').forEach(link => {
-      link.addEventListener('click', () => {
-        navLinks.classList.remove('active');
-      });
+    nav?.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', close);
     });
   }
 
-  // На мобильных .nav-right (шторка языка + переключатель темы + избранное +
-  // бургер) физически не помещается в 375px рядом с логотипом — сдвигаем
-  // переключатели языка/темы в выпадающее меню, а не просто прячем их.
-  // Переносим сами узлы (не клоны), чтобы id/обработчики остались рабочими;
-  // якорь-комментарий помнит, куда вернуть их обратно на десктопе.
+  // На мобильных верхняя панель не вмещает язык/тему/логин рядом с лого —
+  // переключатель языка, темы и кнопка "Войти" переезжают в подвал шторки
+  // (см. мокап SiteHeader); иконка избранного остаётся в верхней панели
+  // всегда. Переносим сами узлы (не клоны), чтобы id/обработчики остались
+  // рабочими; якорь-комментарий помнит, куда вернуть их обратно на десктопе.
   function initMobileNavControls() {
-    const navLinks = document.querySelector('.nav-links');
+    const footer = document.getElementById('navDrawerFooter');
     const langSwitch = document.getElementById('langSwitch');
     const themeToggle = document.getElementById('themeToggle');
-    const favBtn = document.querySelector('.nav-right .nav-icon-btn');
-    if (!navLinks || !langSwitch || !themeToggle) return;
+    const authLink = document.getElementById('navAuthLink');
+    if (!footer || !langSwitch || !themeToggle || !authLink) return;
 
-    const favAnchor = favBtn ? document.createComment('fav-btn-anchor') : null;
-    if (favBtn) favBtn.before(favAnchor);
     const langAnchor = document.createComment('lang-switch-anchor');
     const themeAnchor = document.createComment('theme-toggle-anchor');
+    const authAnchor = document.createComment('auth-link-anchor');
     langSwitch.before(langAnchor);
     themeToggle.before(themeAnchor);
+    authLink.before(authAnchor);
 
-    const favLi = favBtn ? document.createElement('li') : null;
-    if (favLi) {
-      favLi.className = 'nav-mobile-extra';
-      favLi.appendChild(favBtn);
-    }
+    const phoneLink = footer.querySelector('.nav-drawer__phone');
 
-    const langLi = document.createElement('li');
-    langLi.className = 'nav-mobile-extra';
-    langLi.appendChild(langSwitch);
-
-    const themeLi = document.createElement('li');
-    themeLi.className = 'nav-mobile-extra';
-    themeLi.appendChild(themeToggle);
-
-    const mq = window.matchMedia('(max-width: 768px)');
+    const mq = window.matchMedia('(max-width: 920px)');
     function apply(isMobile) {
       if (isMobile) {
-        // Тема — сначала, избранное — затем, шторка языка — последней: её
-        // выпадающее меню раскрывается вниз и иначе перекрывало бы то, что
-        // идёт следом.
-        navLinks.appendChild(themeLi);
-        if (favLi) navLinks.appendChild(favLi);
-        navLinks.appendChild(langLi);
+        footer.insertBefore(langSwitch, phoneLink);
+        footer.insertBefore(themeToggle, phoneLink);
+        footer.insertBefore(authLink, phoneLink);
       } else {
         langAnchor.after(langSwitch);
         themeAnchor.after(themeToggle);
-        if (favBtn) favAnchor.after(favBtn);
+        authAnchor.after(authLink);
       }
     }
     apply(mq.matches);
@@ -1737,7 +1735,7 @@
     loadPartial('siteHeader', './partials/navbar.html', () => {
     initTheme();
     initLang();
-    initBurger();
+    initMobileDrawer();
     initAuthNav();
     initActiveNav();
     initFavNav();

--- a/china-motors-site/partials/navbar.html
+++ b/china-motors-site/partials/navbar.html
@@ -55,8 +55,31 @@
       </a>
 
       <!-- Burger -->
-      <button class="menu-toggle" aria-label="Menu">☰</button>
+      <button class="menu-toggle" id="navBurger" aria-label="Menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
     </div>
 
   </div>
 </header>
+
+<!-- Mobile drawer -->
+<div class="nav-drawer-overlay" id="navDrawerOverlay"></div>
+<aside class="nav-drawer" id="navDrawer">
+  <div class="nav-drawer__header">
+    <span class="nav-drawer__logo"><span class="logo-china">CHINA</span> MOTORS</span>
+    <button class="nav-drawer__close" id="navDrawerClose" aria-label="Закрыть">✕</button>
+  </div>
+  <nav class="nav-drawer__nav" id="navDrawerNav">
+    <a href="index.html" data-i18n="nav_home">Главная</a>
+    <a href="catalog.html" data-i18n="nav_catalog">Каталог</a>
+    <a href="calculator.html" data-i18n="nav_calculator">Калькулятор</a>
+    <a href="favorites.html" data-i18n="nav_favorites">Избранное</a>
+    <a href="contacts.html" data-i18n="nav_contacts">Контакты</a>
+  </nav>
+  <div class="nav-drawer__footer" id="navDrawerFooter">
+    <a href="tel:+77776133731" class="nav-drawer__phone">+7 (777) 613-3731</a>
+  </div>
+</aside>

--- a/china-motors-site/style.css
+++ b/china-motors-site/style.css
@@ -873,21 +873,12 @@ html.dark .contact-form textarea {
     right: 0;
     display: flex;
   }
-  .menu-toggle {
-    display: block;     /* ← теперь он виден */
-  }
-  .navbar .menu-toggle {
-    display: block;
-    padding: 15px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-size: 26px;
-    color: #12172a;
-    z-index: 100;
-    transform: translateX(-10px);
-  }
-  html.dark .navbar .menu-toggle { color: #fff; }
+  /* .menu-toggle/.navbar .menu-toggle styling lives in the dedicated
+     nav-drawer block below (920px breakpoint) -- this legacy 768px block
+     predates the current navbar markup (.navbar .container/.close-btn
+     don't exist anymore) and its more-specific .navbar .menu-toggle rule
+     would otherwise fight the drawer burger's padding/size in the
+     481-768px overlap. */
 
   .nav-links .close-btn {
     position: absolute;
@@ -1638,72 +1629,190 @@ html.dark .privacy-container a {
   padding: 4px 6px;
   border-radius: 6px;
 }
-/* mobile */
-@media (max-width: 768px) {
-  .nav-links {
-    position: fixed;
-    top: 0;
-    right: -100%;
-    width: 70%;
-    height: 100vh;
-    flex-direction: column;
-    justify-content: flex-start;
-    background: #1f1f1f;
-    padding: 80px 20px;
-    transition: right 0.3s ease;
-    gap: 20px;
-
+/* =========================================================
+   MOBILE NAV DRAWER (matches SiteHeader mockup, 920px breakpoint)
+   ========================================================= */
+@media (max-width: 920px) {
+  .nav-links,
+  #langSwitch,
+  .nav-auth-link {
+    display: none !important;
   }
-
-  .nav-links.active {
-    right: 0;
+  .menu-toggle {
+    display: flex !important;
   }
-
-  /* .nav-links stops being a flex item once it's position:fixed, so the
-     overflow on small screens actually comes from .nav-left + the huge
-     desktop gap + .nav-right's 5 non-shrinking controls. #langSwitch,
-     #themeToggle and the favorites icon get moved into this drawer by JS
-     at this same breakpoint (see initMobileNavControls in common.js) so
-     nav-right only has to fit the auth pill + burger. */
+  /* "СПЕЦТЕХНИКА ИЗ КИТАЯ" at 2px letter-spacing renders wider than the
+     "China Motors" title above it -- tighten it instead of hiding it. */
+  .logo-sub {
+    font-size: 8px;
+    letter-spacing: 0.5px;
+  }
   .container-navbar {
     gap: 8px;
     justify-content: space-between;
   }
   .nav-right {
-    gap: 6px;
+    gap: 8px;
   }
-  .nav-auth-link {
-    padding: 9px 12px;
-    font-size: 12px;
-    max-width: 110px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .navbar .menu-toggle {
-    padding: 10px;
-    font-size: 22px;
-  }
-  /* "СПЕЦТЕХНИКА ИЗ КИТАЯ" at 2px letter-spacing is wider than the "China
-     Motors" title above it and was the single biggest driver of navbar
-     overflow -- tighten it down instead of hiding it outright. */
-  .logo-sub {
-    font-size: 8px;
-    letter-spacing: 0.5px;
-  }
-  .nav-mobile-extra {
-    width: 100%;
-    display: flex;
-  }
-  .nav-mobile-extra .lang-switch {
-    width: 100%;
-  }
-  .nav-mobile-extra .lang-toggle,
-  .nav-mobile-extra #themeToggle {
-    width: 100%;
-    justify-content: flex-start;
-    gap: 10px;
-  }
+}
+
+.menu-toggle {
+  display: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid #e4e6eb;
+  background: #fff;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 5px;
+  padding: 0;
+  flex-shrink: 0;
+}
+html.dark .menu-toggle { background: #2a2a2a; border-color: rgba(255,255,255,.12); }
+.menu-toggle span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  border-radius: 2px;
+  background: #12172a;
+}
+html.dark .menu-toggle span { background: #f5f5f5; }
+
+.nav-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(13,17,32,0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .25s ease, visibility .25s ease;
+}
+.nav-drawer-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.nav-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 201;
+  width: min(84vw, 320px);
+  background: #fff;
+  box-shadow: -12px 0 40px rgba(13,17,32,0.2);
+  transform: translateX(100%);
+  transition: transform .28s cubic-bezier(.4,0,.2,1);
+  display: flex;
+  flex-direction: column;
+}
+.nav-drawer.active {
+  transform: translateX(0);
+}
+html.dark .nav-drawer { background: #1e1e1e; }
+
+.nav-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  border-bottom: 1px solid #e4e6eb;
+  flex-shrink: 0;
+}
+html.dark .nav-drawer__header { border-color: rgba(255,255,255,.08); }
+
+.nav-drawer__logo {
+  font-family: 'Oswald', sans-serif;
+  font-weight: 700;
+  font-size: 17px;
+  color: #12172a;
+}
+html.dark .nav-drawer__logo { color: #f5f5f5; }
+.nav-drawer__logo .logo-china { color: #E12821; }
+
+.nav-drawer__close {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  border: 1px solid #e4e6eb;
+  background: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+  color: #12172a;
+}
+html.dark .nav-drawer__close { background: #2a2a2a; border-color: rgba(255,255,255,.12); color: #f5f5f5; }
+
+.nav-drawer__nav {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  overflow-y: auto;
+  gap: 2px;
+}
+.nav-drawer__nav a {
+  padding: 14px 12px;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 500;
+  color: #12172a;
+  text-decoration: none;
+}
+html.dark .nav-drawer__nav a { color: #f5f5f5; }
+.nav-drawer__nav a.active {
+  font-weight: 600;
+  color: #E12821;
+  background: #f5f6f8;
+}
+html.dark .nav-drawer__nav a.active { background: rgba(225,40,33,0.15); }
+
+.nav-drawer__footer {
+  padding: 16px 20px;
+  border-top: 1px solid #e4e6eb;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex-shrink: 0;
+}
+html.dark .nav-drawer__footer { border-color: rgba(255,255,255,.08); }
+
+.nav-drawer__phone {
+  text-align: center;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: #12172a;
+  text-decoration: none;
+}
+html.dark .nav-drawer__phone { color: #f5f5f5; }
+
+/* langSwitch/themeToggle/auth-link get relocated in here by JS on mobile
+   (initMobileDrawer in common.js) -- same live nodes, full-width now. */
+.nav-drawer__footer #langSwitch,
+.nav-drawer__footer #themeToggle,
+.nav-drawer__footer .nav-auth-link {
+  display: flex !important;
+  width: 100%;
+}
+.nav-drawer__footer .lang-toggle {
+  width: 100%;
+  justify-content: space-between;
+}
+.nav-drawer__footer .nav-auth-link {
+  justify-content: center;
+  padding: 14px;
+  max-width: none;
+}
+.nav-drawer__footer #themeToggle {
+  justify-content: flex-start;
+  gap: 10px;
+  padding: 10px 4px;
 }
 .nav-logo {
   flex: 0 0 auto;


### PR DESCRIPTION
Replaces the patched-together approach (reusing .nav-links as a sliding panel, relocating controls into it ad hoc) with a proper purpose-built mobile drawer matching the supplied mockup: a right-side <aside> with its own header (logo + close button), nav list, and footer, plus a dedicated overlay -- not a repurposed desktop element.

Adapted to the real site rather than copied 1:1: no Услуги / Как это работает links (that page was deleted earlier this session), added Избранное as a real drawer nav link, and the footer's language switcher / theme toggle / auth button are the site's actual working controls (not decorative) -- moved into the drawer at <=920px via the same DOM-relocation technique as before (real nodes, not clones, so ids and listeners keep working), restored to the top bar above that. The favorites icon now stays visible in the top bar at every width, matching the mockup, instead of also being relocated.

Breakpoint moved to 920px (was 768px) to match the mockup. Replaced the burger's plain "☰" character with a proper 3-line icon per the mockup, and removed a legacy, unreachable 768px media query block (referenced .navbar .container/.close-btn, neither of which exist in the current markup) whose more-specific .navbar .menu-toggle rule would otherwise have fought the new burger's sizing in the 481-768px overlap.

Verified via Playwright: desktop nav-right still has all 5 controls and is visually unchanged; on mobile the burger sits fully inside the viewport with the favorites icon, and opening the drawer confirms language switching, dark-mode toggling, and navigation (with auto-close) all work correctly from inside it; close button, overlay click, and Escape all close it; no horizontal overflow on any of the 8 main pages.